### PR TITLE
Include README in gem package.

### DIFF
--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |spec|
                         "lib/generators/raygun/install_generator.rb",
                         "lib/raygun/testable.rb",
                         "lib/tasks/raygun.tasks",
-                        "lib/resque/failure/raygun.rb"]
+                        "lib/resque/failure/raygun.rb",
+                        "README.md"]
 
   spec.executables   = []
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This is useful if a developer has the source of the gem (for example,
in their bundle directory) but no internet connection, and wants to
learn more about how the gem should be used.
