### PR TITLE
Moved silence_reporting setting to the generated initializer for Rails.

### DIFF
--- a/lib/generators/raygun/install_generator.rb
+++ b/lib/generators/raygun/install_generator.rb
@@ -9,6 +9,7 @@ module Raygun
         <<-EOS
 Raygun.setup do |config|
   config.api_key = "#{api_key}"
+  config.silence_reporting = !Rails.env.production?
 end
 EOS
       end

--- a/lib/raygun/railtie.rb
+++ b/lib/raygun/railtie.rb
@@ -16,7 +16,6 @@ class Raygun::Railtie < Rails::Railtie
 
   config.to_prepare do
     Raygun.configuration.logger            ||= Rails.logger
-    Raygun.configuration.silence_reporting ||= !Rails.env.production?
   end
 
   rake_tasks do


### PR DESCRIPTION
The problem was that the Railtie ran after the initializer so the value set in the initializer would be overwritten by the Railtie based only on environment.  This made it impossible to base the silence_reporting setting on anything but the production environment.

This works fine for the logger since it's `nil` by default so the Railtie will only overwrite it if it hasn't been set.  This doesn't work for `silence_reporting` since it's a boolean.

By adding `silence_reporting` to the generated initializer, the default is still preserved in a Rails app and it makes it obvious how to change it as well.
