### PR TITLE
Flatten ignored exceptions.

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -69,7 +69,7 @@ module Raygun
 
       def should_report?(exception)
         return false if configuration.silence_reporting
-        return false if configuration.ignore.include?(exception.class.to_s)
+        return false if configuration.ignore.flatten.include?(exception.class.to_s)
         true
       end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -3,6 +3,7 @@ require_relative "../test_helper.rb"
 class ConfigurationTest < Raygun::UnitTest
 
   class TestException < StandardError; end
+  class Test2Exception < StandardError; end
 
   def setup
     Raygun.setup do |config|
@@ -31,6 +32,13 @@ class ConfigurationTest < Raygun::UnitTest
     Raygun.configuration.ignore << TestException.to_s
 
     assert_nil Raygun.track_exception(TestException.new)
+  end
+
+  def test_ignoring_multiple_exceptions
+    Raygun.configuration.ignore << [TestException.to_s, Test2Exception.to_s]
+
+    assert_nil Raygun.track_exception(TestException.new)
+    assert_nil Raygun.track_exception(Test2Exception.new)
   end
 
   def test_default_values


### PR DESCRIPTION
This part of [readme](https://github.com/MindscapeHQ/raygun4ruby/blob/169e9896c1852de1dbe1f15796292bb0120eafae/README.md#ignoring-some-errors) doesn't work now.

You need to pass exception instead of array.

``` ruby
config.ignore  << MyApp::AnExceptionIDontCareAbout
```

To allow multiple exceptions onliner I added flatten when it's accessing ignore array.

``` ruby
config.ignore  << [MyApp::AnExceptionIDontCareAbout, MyApp::AnExceptionIDontCareAboutAlso]
```
