### PR TITLE
fix bad encoding in error message

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -35,7 +35,7 @@ module Raygun
       def error_details(exception)
         {
           className:  exception.class.to_s,
-          message:    exception.message,
+          message:    exception.message.encode('UTF-16', :undef => :replace, :invalid => :replace).encode('UTF-8'),
           stackTrace: (exception.backtrace || []).map { |line| stack_trace_for(line) }
         }
       end
@@ -135,7 +135,7 @@ module Raygun
           result[k] = case v
           when Hash
             filter_params(v, extra_filter_keys)
-          else 
+          else
             filter_keys.include?(k) ? "[FILTERED]" : v
           end
           result

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require_relative "../test_helper.rb"
 require 'stringio'
 
@@ -73,6 +74,20 @@ class ClientTest < Raygun::UnitTest
 
   def test_hostname
     assert_equal Socket.gethostname, @client.send(:hostname)
+  end
+
+  def test_unicode
+    e = TestException.new('日本語のメッセージ')
+
+    assert_silent { @client.track_exception(e) }
+  end
+
+  def test_bad_encoding
+    bad_message   = (100..1000).to_a.pack('c*').force_encoding('utf-8')
+    bad_exception = TestException.new(bad_message)
+
+    assert !bad_message.valid_encoding?
+    assert_silent { @client.track_exception(bad_exception) }
   end
 
   def test_full_payload_hash


### PR DESCRIPTION
Exception messages could be incorrectly encoded string due to bad data or bug in application.

This resolves https://github.com/MindscapeHQ/raygun4ruby/issues/22
