### PR TITLE
Handle nil method names

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -49,7 +49,7 @@ module Raygun
         {
           lineNumber: line_number,
           fileName:   file_name,
-          methodName: method.gsub(/^in `(.*?)'$/, "\\1")
+          methodName: method ? method.gsub(/^in `(.*?)'$/, "\\1") : "(none)"
         }
       end
 

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -90,6 +90,18 @@ class ClientTest < Raygun::UnitTest
     assert_silent { @client.track_exception(bad_exception) }
   end
 
+  def test_backtrace_without_method_name
+
+    expected = {
+      lineNumber: "123",
+      fileName:   "/some/folder/some_file.rb",
+      methodName: "(none)"
+    }
+
+    # note lack of "in method name" in this stack trace line
+    assert_equal expected, @client.send(:stack_trace_for, "/some/folder/some_file.rb:123")
+  end
+
   def test_full_payload_hash
     Timecop.freeze do
       Raygun.configuration.version = 123


### PR DESCRIPTION
Ensure the client doesn't error out if no method name is specified in the exception backtrace
