### PR TITLE
Handle exceptions which return a nil message

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -38,7 +38,7 @@ module Raygun
       def error_details(exception)
         {
           className:  exception.class.to_s,
-          message:    exception.message.encode('UTF-16', :undef => :replace, :invalid => :replace).encode('UTF-8'),
+          message:    exception.message.to_s.encode('UTF-16', :undef => :replace, :invalid => :replace).encode('UTF-8'),
           stackTrace: (exception.backtrace || []).map { |line| stack_trace_for(line) }
         }
       end

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -5,6 +5,11 @@ require 'stringio'
 class ClientTest < Raygun::UnitTest
 
   class TestException < StandardError; end
+  class NilMessageError < StandardError
+    def message
+      nil
+    end
+  end
 
   class FakeActionDispatcherIp
     attr_reader :ip
@@ -53,6 +58,12 @@ class ClientTest < Raygun::UnitTest
     }
 
     assert_equal expected_hash, @client.send(:error_details, e)
+  end
+
+  def test_error_details_with_nil_message
+    e = NilMessageError.new
+    expected_message = ""
+    assert_equal expected_message, @client.send(:error_details, e)[:message]
   end
 
   def test_client_details


### PR DESCRIPTION
Raygun can't track errors whose `.message` returns `nil`. Calling `.to_s` before encoding the message in the  `error_details` method fixes this.

The added test is kinda gross, sorry.

E.g. The Evernote gem can throw errors which, for reasons unknown, has `nil` for the message. Other gems could probably do the same thing, and it'd be good for Raygun to handle this case.

```
2.1.1 :005 > t = Thrift::Exception.new(nil)
 => #<Thrift::Exception: Thrift::Exception> 
2.1.1 :006 > t.message
 => nil 
2.1.1 :015 > Raygun.track_exception(t)
NoMethodError: undefined method `encode' for nil:NilClass
from /Users/nickmalcolm/.rvm/gems/ruby-2.1.1/gems/raygun4ruby-1.0.1/lib/raygun/client.rb:38:in `error_details'
from /Users/nickmalcolm/.rvm/gems/ruby-2.1.1/gems/raygun4ruby-1.0.1/lib/raygun/client.rb:113:in `build_payload_hash'
from /Users/nickmalcolm/.rvm/gems/ruby-2.1.1/gems/raygun4ruby-1.0.1/lib/raygun/client.rb:22:in `track_exception'
from /Users/nickmalcolm/.rvm/gems/ruby-2.1.1/gems/raygun4ruby-1.0.1/lib/raygun.rb:44:in `track_exception'
```

Evernote's exception class: https://github.com/evernote/evernote-sdk-ruby/blob/master/lib/thrift/exceptions.rb
