### PR TITLE
Add note about enable_reporting to install notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ NB: Raygun4Ruby currently requires Ruby >= 1.9
 
 Note that the generator will create a file in `config/initializers` called "raygun.rb". If you need to do any further configuration or customization of Raygun, that's the place to do it!
 
+By default the Rails integration is set to only report Exceptions in Production. To change this behaviour, set `config.enable_reporting` to something else in `config/initializers/raygun.rb`.
+
 ### Rails 2
 
 Raygun4Ruby doesn't currently support Rails 2. If you'd like Rails 2 support, [drop us a line](http://raygun.io/forums).


### PR DESCRIPTION
Have had a few customer queries about this over the last few months, seems to be a common pitfall.
