### PR TITLE
Don't raise when API Key Is missing

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -21,9 +21,6 @@ module Raygun
   CLIENT_URL  = "https://github.com/MindscapeHQ/raygun4ruby"
   CLIENT_NAME = "Raygun4Ruby Gem"
 
-  # Exceptions
-  class ApiKeyRequired < StandardError; end
-
   class << self
 
     include Testable

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -4,14 +4,14 @@ module Raygun
   class Client
 
     ENV_IP_ADDRESS_KEYS = %w(action_dispatch.remote_ip raygun.remote_ip REMOTE_ADDR)
+    NO_API_KEY_MESSAGE  = "[RAYGUN] Just a note, you've got no API Key configured, which means we can't report exceptions. Specify your Raygun API key using Raygun#setup (find yours at https://app.raygun.io)"
 
     include HTTParty
 
     base_uri "https://api.raygun.io/"
 
     def initialize
-      @api_key = require_api_key!
-
+      @api_key = require_api_key
       @headers = {
         "X-ApiKey" => @api_key
       }
@@ -19,8 +19,8 @@ module Raygun
       enable_http_proxy if Raygun.configuration.proxy_settings[:address]
     end
 
-    def require_api_key!
-      Raygun.configuration.api_key || raise(ApiKeyRequired.new("Please specify your Raygun API key using Raygun#setup (find yours at https://app.raygun.io)"))
+    def require_api_key
+      Raygun.configuration.api_key || print_api_key_warning
     end
 
     def track_exception(exception_instance, env = {})
@@ -192,6 +192,10 @@ module Raygun
           return env_hash[key_to_try] unless env_hash[key_to_try].nil? || env_hash[key_to_try] == ""
         end
         "(Not Available)"
+      end
+
+      def print_api_key_warning
+        $stderr.puts(NO_API_KEY_MESSAGE)
       end
 
   end

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rack"
 
   spec.add_development_dependency "bundler", ">= 1.1"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "0.9.6"
   spec.add_development_dependency "fakeweb", ["~> 1.3"]
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "minitest", "~> 4.2"

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -27,12 +27,11 @@ class ClientTest < Raygun::UnitTest
     fake_successful_entry
   end
 
-  def test_api_key_required_exception
+  def test_api_key_required_message
     Raygun.configuration.api_key = nil
 
-    assert_raises Raygun::ApiKeyRequired do
-      second_client = Raygun::Client.new
-    end
+    $stderr.expects(:puts).with(Raygun::Client::NO_API_KEY_MESSAGE).once
+    second_client = Raygun::Client.new
   end
 
   def test_track_exception


### PR DESCRIPTION
Adds a stderr message rather than raising when API Key config is missing

(Fixes #62)