### PR TITLE
Allow tags to be set in configuration

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -147,10 +147,10 @@ module Raygun
             client:         client_details,
             error:          error_details(exception_instance),
             userCustomData: Raygun.configuration.custom_data.merge(custom_data),
+            tags:           Raygun.configuration.tags.concat(tags).uniq,
             request:        request_information(env)
         }
 
-        error_details.merge!(tags: tags)
         error_details.merge!(user: user_information(env)) if affected_user_present?(env)
 
         {

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -23,6 +23,9 @@ module Raygun
     # Custom Data to send with each exception
     config_option :custom_data
 
+    # Tags to send with each exception
+    config_option :tags
+
     # Logger to use when if we find an exception :)
     config_option :logger
 
@@ -65,6 +68,7 @@ module Raygun
       @defaults = OpenStruct.new({
         ignore:                           IGNORE_DEFAULT,
         custom_data:                      {},
+        tags:                             [],
         enable_reporting:                 true,
         affected_user_method:             :current_user,
         affected_user_identifier_methods: [ :email, :username, :id ],

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -93,11 +93,19 @@ class ClientTest < Raygun::UnitTest
   end
 
   def test_tags
-    e             = TestException.new("A test message")
-    test_env      = { tags: %w{one two three four} }
-    expected_hash = %w{one two three four test}
+    configuration_tags = %w{alpha beta gaga}
+    explicit_env_tags  = %w{one two three four}
+    rack_env_tag       = %w{test}
 
-    assert_equal expected_hash, @client.send(:build_payload_hash, e, test_env)[:details][:tags]
+    Raygun.setup do |config|
+      config.tags = configuration_tags
+    end
+
+    e             = TestException.new("A test message")
+    test_env      = { tags: explicit_env_tags }
+    expected_tags =  configuration_tags + explicit_env_tags + rack_env_tag
+
+    assert_equal expected_tags, @client.send(:build_payload_hash, e, test_env)[:details][:tags]
   end
 
   def test_hostname

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -52,6 +52,10 @@ class ConfigurationTest < Raygun::UnitTest
     assert_equal({}, Raygun.configuration.custom_data)
   end
 
+  def test_default_tags_set
+    assert_equal([], Raygun.configuration.tags)
+  end
+
   def test_overriding_defaults
     Raygun.default_configuration.custom_data = { robby: "robot" }
     assert_equal({ robby: "robot" }, Raygun.configuration.custom_data)


### PR DESCRIPTION
Resolves issue #72.

Adds a `tags` config option which allows users to set an array of tags which will be passed with every exception sent to the API. 

Example usage:

```ruby
Raygun.setup do |config|
  config.tags = ['heroku']
end
```
