### PR TITLE
Fix (JSON::GeneratorError) "source sequence is illegal/malformed utf-8"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ before_install:
 rvm:
  - 1.9.3
  - 2.0.0
+ - 2.1
+ - 2.2
 
 gemfile:
   - Gemfile

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -160,7 +160,7 @@ module Raygun
       end
 
       def create_entry(payload_hash)
-        self.class.post("/entries", headers: @headers, body: JSON.generate(payload_hash))
+        self.class.post("/entries", headers: @headers, body: JSON.generate(hash_to_utf8(payload_hash)))
       end
 
       def filter_params(params_hash, extra_filter_keys = nil)
@@ -170,6 +170,20 @@ module Raygun
           filter_keys = (Array(extra_filter_keys) + Raygun.configuration.filter_parameters).map(&:to_s)
           filter_params_with_array(params_hash, filter_keys)
         end
+      end
+
+      def hash_to_utf8(hash)
+        Hash[
+            hash.collect do |k, v|
+              if v.is_a?(Hash)
+                [k, hash_to_utf8(v)]
+              elsif v.respond_to?(:encode)
+                [k, v.encode('UTF-8', :invalid => :replace, :undef => :replace)]
+              else
+                [k, v]
+              end
+            end
+        ]
       end
 
       def filter_params_with_proc(params_hash, proc)

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -173,6 +173,11 @@ class ClientTest < Raygun::UnitTest
     end
   end
 
+  def test_not_utf8
+    custom_data = {key: "R\xE9cup\xE9rez"}
+    assert_silent { @client.send(:create_entry, {custom_data: custom_data})}
+  end
+
   def test_getting_request_information
     sample_env_hash = {
       "SERVER_NAME"=>"localhost",


### PR DESCRIPTION
Remove no utf8 characters from payload hash
If no utf8 characters are passed in the custom data (in case of putting user input data inside of it), it fails to generate the json.

ToDo: make this working on 1.9.3 and 2.0.0 (works on 2.1 and 2.2)