### PR TITLE
Remove deprecation warnings when using Rails 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 before_install:
   - gem install bundler
 
+script:
+  - bundle exec rake
+
 rvm:
  - 1.9.3
  - 2.0.0
+ - 2.2.5
+ - 2.3.1
 
 gemfile:
   - Gemfile


### PR DESCRIPTION
When running a Rails 5.0.0.beta4 web app with the lastest version of Raygun4ruby, I get this:

```bash
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "ActionDispatch::DebugExceptions" => ActionDispatch::DebugExceptions

 (called from get_class at /usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.0.beta4/lib/action_dispatch/middleware/stack.rb:116)
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "Raygun::Middleware::RackExceptionInterceptor" => Raygun::Middleware::RackExceptionInterceptor

 (called from get_class at /usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.0.beta4/lib/action_dispatch/middleware/stack.rb:116)
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "Raygun::Middleware::RailsInsertAffectedUser" => Raygun::Middleware::RailsInsertAffectedUser

 (called from get_class at /usr/local/opt/rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/actionpack-5.0.0.beta4/lib/action_dispatch/middleware/stack.rb:116)
```

This Pull Request should fix it.