### PR TITLE
Manual exception user data passing & readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ You should see an "ItWorksException" appear in your Raygun dashboard. You're rea
 
 NB: Raygun4Ruby currently requires Ruby >= 1.9
 
-Note that the generator will create a file in `config/initializers` called "raygun.rb". If you
-need to do any further configuration/customization of Raygun, that's the place to do it!
+Note that the generator will create a file in `config/initializers` called "raygun.rb". If you need to do any further configuration/customization of Raygun, that's the place to do it!
 
 By default the Rails integration is set to only report Exceptions in Production. To change this behaviour, set `config.enable_reporting` to something else in `config/initializers/raygun.rb`.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You should see an "ItWorksException" appear in your Raygun dashboard. You're rea
 
 NB: Raygun4Ruby currently requires Ruby >= 1.9
 
-Note that the generator will create a file in `config/initializers` called "raygun.rb". If you need to do any further configuration or customization of Raygun, that's the place to do it!
+Note that the generator will create a file in `config/initializers` called "raygun.rb". If you
+need to do any further configuration/customization of Raygun, that's the place to do it!
 
 By default the Rails integration is set to only report Exceptions in Production. To change this behaviour, set `config.enable_reporting` to something else in `config/initializers/raygun.rb`.
 
@@ -56,6 +57,7 @@ use Raygun::Middleware::RackExceptionInterceptor
 ```
 
 ### Standalone / Manual Exception Tracking
+*Standalone / Manual Exception Tracking will not automatically track user details.*
 
 ```ruby
 
@@ -91,7 +93,7 @@ Raygun.setup do |config|
 end
 ```
 
-### Custom User Data
+### Custom Data
 Custom data can be added to `track_exception` by passing a custom_data key in the second parameter hash.
 
 ```ruby
@@ -135,7 +137,7 @@ Raygun.setup do |config|
 end
 ```
 
-### Affected User Tracking
+### Affected User Tracking - Automatic Exception Tracking
 
 Raygun can now track how many users have been affected by an error.
 
@@ -168,6 +170,22 @@ end
 ```
 
 (Remember to set `affected_user_method` to `:raygun_user` in your config block...)
+
+### Affected User Tracking - Manual Exception Tracking (Rails controllers)
+
+You can also send user information for manually tracked exception in a Rails controller by passing `env`
+as the second parameter to `track_exception`.  
+
+```ruby
+begin
+  # more lovely code
+rescue Exception => e
+  Raygun.track_exception(e, env)
+end
+```
+You will need to configure the `affected_user_method` and `affected_user_identifier_methods`
+settings in `/config/initializers/raygun.rb` if your Rails controllers do not have a `:current_user`
+method or if the object that method returns does not respond to `:email`, `:username`, or `:id`.
 
 ### Version tracking
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You should see an "ItWorksException" appear in your Raygun dashboard. You're rea
 
 NB: Raygun4Ruby currently requires Ruby >= 1.9
 
-Note that the generator will create a file in `config/initializers` called "raygun.rb". If you need to do any further configuration/customization of Raygun, that's the place to do it!
+Note that the generator will create a file in `config/initializers` called "raygun.rb". If you need to do any further configuration or customization of Raygun, that's the place to do it!
 
 By default the Rails integration is set to only report Exceptions in Production. To change this behaviour, set `config.enable_reporting` to something else in `config/initializers/raygun.rb`.
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -71,7 +71,7 @@ module Raygun
       end
 
       def user_information(env)
-        env["raygun.affected_user"] || env["action_controller.instance"].current_user
+        env["raygun.affected_user"] || env["action_controller.instance"].current_user.email
       end
 
       def affected_user_present?(env)
@@ -79,7 +79,7 @@ module Raygun
       end
 
       def current_user_present?(env)
-        !!env["action_controller.instance"].current_user.email
+        !!env["action_controller.instance"].current_user
       end
 
       def rack_env

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -71,7 +71,7 @@ module Raygun
       end
 
       def user_information(env)
-        env["raygun.affected_user"] || env["action_controller.instance"].current_user.email
+        env["raygun.affected_user"] || get_current_user_identifier(env)
       end
 
       def affected_user_present?(env)
@@ -80,6 +80,10 @@ module Raygun
 
       def current_user_present?(env)
         !!env["action_controller.instance"].current_user
+      end
+
+      def get_current_user_identifier(env)
+        { identifier: "#{env["action_controller.instance"].current_user.email}"}
       end
 
       def rack_env

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -71,7 +71,7 @@ module Raygun
       end
 
       def user_information(env)
-        env["raygun.affected_user"] # || get_current_user_identifier(env)
+        env["raygun.affected_user"] || get_current_user_identifier(env)
       end
 
       def affected_user_present?(env)
@@ -82,9 +82,9 @@ module Raygun
         !!env["action_controller.instance"].current_user
       end
 
-      # def get_current_user_identifier(env)
-      #   { identifier: "#{env["action_controller.instance"].current_user.email}"}
-      # end
+      def get_current_user_identifier(env)
+        { identifier: "#{env["action_controller.instance"].current_user.email}"}
+      end
 
       def rack_env
         ENV["RACK_ENV"]

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -71,12 +71,15 @@ module Raygun
       end
 
       def user_information(env)
-        env["raygun.affected_user"]
+        env["raygun.affected_user"] || env["action_controller.instance"].current_user
       end
 
       def affected_user_present?(env)
         !!env["raygun.affected_user"]
       end
+
+      def current_user_present?(env)
+        !!env["action_controller.instance"].current_user
 
       def rack_env
         ENV["RACK_ENV"]
@@ -155,7 +158,7 @@ module Raygun
 
         error_details.merge!(groupingKey: grouping_key) if grouping_key
 
-        error_details.merge!(user: user_information(env)) if affected_user_present?(env)
+        error_details.merge!(user: user_information(env)) if affected_user_present?(env) || current_user_present?(env)
 
         {
           occurredOn: Time.now.utc.iso8601,

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -79,9 +79,9 @@ module Raygun
       end
 
       def current_user_present?(env)
-        !!env["action_controller.instance"].current_user
+        !!env["action_controller.instance"].current_user.email
       end
-      
+
       def rack_env
         ENV["RACK_ENV"]
       end

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -80,7 +80,8 @@ module Raygun
 
       def current_user_present?(env)
         !!env["action_controller.instance"].current_user
-
+      end
+      
       def rack_env
         ENV["RACK_ENV"]
       end

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -71,7 +71,7 @@ module Raygun
       end
 
       def user_information(env)
-        env["raygun.affected_user"] || get_current_user_identifier(env)
+        env["raygun.affected_user"] # || get_current_user_identifier(env)
       end
 
       def affected_user_present?(env)
@@ -82,9 +82,9 @@ module Raygun
         !!env["action_controller.instance"].current_user
       end
 
-      def get_current_user_identifier(env)
-        { identifier: "#{env["action_controller.instance"].current_user.email}"}
-      end
+      # def get_current_user_identifier(env)
+      #   { identifier: "#{env["action_controller.instance"].current_user.email}"}
+      # end
 
       def rack_env
         ENV["RACK_ENV"]

--- a/lib/raygun/middleware/rails_insert_affected_user.rb
+++ b/lib/raygun/middleware/rails_insert_affected_user.rb
@@ -14,7 +14,6 @@ module Raygun
           user = controller.send(Raygun.configuration.affected_user_method)
 
           if user
-            byebug
             identifier = if (m = Raygun.configuration.affected_user_identifier_methods.detect { |m| user.respond_to?(m) })
               user.send(m)
             else

--- a/lib/raygun/middleware/rails_insert_affected_user.rb
+++ b/lib/raygun/middleware/rails_insert_affected_user.rb
@@ -14,6 +14,7 @@ module Raygun
           user = controller.send(Raygun.configuration.affected_user_method)
 
           if user
+            byebug
             identifier = if (m = Raygun.configuration.affected_user_identifier_methods.detect { |m| user.respond_to?(m) })
               user.send(m)
             else
@@ -22,7 +23,7 @@ module Raygun
 
             env["raygun.affected_user"] = { :identifier => identifier }
           end
-          
+
         end
         raise exception
       end


### PR DESCRIPTION
Added a method (didn't make it pretty, sorry) to the `raygun/client.rb` file to recreate the same logic for setting the `raygun.affected_user` env value as in the `raygun/middleware/rails_insert_affected_user.rb` file.  

It's not pretty but enables users to pass user data (and have Raygun interpret it somewhat) via a manual exception handler in a controller.  This won't work for models for the same reasons as the normal, automatic tracking (no readily available environment variable at that level).

I imagine the use case is small, but it doesn't seem to muck anything up and the tests pass.  Started to write new unit tests for it but the lack of an easy (read: quick) way to setup a mock controller environment dissuaded me.  

Currently all unit and integration tests pass with the changes that were made.
### Current Issues:

Only the first of the matching affected_user_identifier_methods is passed along with the exception.  Full name wasn't populated inside Raygun across multiple tests.  Further testing needed.
