### PR TITLE
include innerError with nested errors data

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -45,13 +45,17 @@ module Raygun
       end
 
       def error_details(exception)
-        cause = exception.respond_to?(:cause) && exception.cause
-        {
+        details = {
           className:  exception.class.to_s,
           message:    exception.message.to_s.encode('UTF-16', :undef => :replace, :invalid => :replace).encode('UTF-8'),
           stackTrace: (exception.backtrace || []).map { |line| stack_trace_for(line) },
-          innerError: (cause && error_details(cause) || {} )
         }
+        
+        if cause = exception.respond_to?(:cause) && exception.cause
+          details.update innerError: error_details(cause)
+        end
+
+        details
       end
 
       def stack_trace_for(line)

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -45,10 +45,12 @@ module Raygun
       end
 
       def error_details(exception)
+        cause = exception.respond_to?(:cause) && exception.cause
         {
           className:  exception.class.to_s,
           message:    exception.message.to_s.encode('UTF-16', :undef => :replace, :invalid => :replace).encode('UTF-8'),
-          stackTrace: (exception.backtrace || []).map { |line| stack_trace_for(line) }
+          stackTrace: (exception.backtrace || []).map { |line| stack_trace_for(line) },
+          innerError: (cause && error_details(cause) || {} )
         }
       end
 

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -60,6 +60,39 @@ class ClientTest < Raygun::UnitTest
     assert_equal expected_hash, @client.send(:error_details, e)
   end
 
+  def test_inner_error_details
+    oe = TestException.new("A test message")
+    oe.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'"])
+
+    ie = TestException.new("Inner test message")
+    ie.set_backtrace(["/another/path/foo.rb:1234:in `block (3 levels) run'"])
+
+    e = nest_exceptions(oe, ie)
+
+    expected_hash = {
+      className: "ClientTest::TestException",
+      message:   oe.message,
+      stackTrace: [
+        { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" }
+      ],
+      innerError: {}
+    }
+
+    # test inner error according with its availability (ruby >= 2.1)
+    if e.respond_to? :cause
+      expected_hash[:innerError] = {
+        className: "ClientTest::TestException",
+        message:   ie.message,
+        stackTrace: [
+          { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run"}
+        ],
+        innerError: {}
+      }
+    end
+
+    assert_equal expected_hash, @client.send(:error_details, e)
+  end
+
   def test_error_details_with_nil_message
     e = NilMessageError.new
     expected_message = ""
@@ -396,6 +429,22 @@ class ClientTest < Raygun::UnitTest
   end
 
   private
+
+    def nest_exceptions(outer_exception, inner_exception)
+      begin
+        begin
+          raise inner_exception.class, inner_exception.message
+        rescue => e
+          e.set_backtrace inner_exception.backtrace
+          raise outer_exception.class, outer_exception.message
+        end
+      rescue => nested_exception
+        nested_exception.set_backtrace outer_exception.backtrace
+      end
+
+      nested_exception
+    end
+
 
     def sample_env_hash
       {

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -53,7 +53,8 @@ class ClientTest < Raygun::UnitTest
       stackTrace: [
         { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" },
         { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run"}
-      ]
+      ],
+      innerError: {}
     }
 
     assert_equal expected_hash, @client.send(:error_details, e)
@@ -163,7 +164,8 @@ class ClientTest < Raygun::UnitTest
             stackTrace: [
               { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" },
               { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run"}
-            ]
+            ],
+            innerError: {},
           },
           userCustomData: {},
           tags:           ["test"],

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -53,8 +53,7 @@ class ClientTest < Raygun::UnitTest
       stackTrace: [
         { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" },
         { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run"}
-      ],
-      innerError: {}
+      ]
     }
 
     assert_equal expected_hash, @client.send(:error_details, e)
@@ -74,8 +73,7 @@ class ClientTest < Raygun::UnitTest
       message:   oe.message,
       stackTrace: [
         { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" }
-      ],
-      innerError: {}
+      ]
     }
 
     # test inner error according with its availability (ruby >= 2.1)
@@ -85,8 +83,7 @@ class ClientTest < Raygun::UnitTest
         message:   ie.message,
         stackTrace: [
           { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run"}
-        ],
-        innerError: {}
+        ]
       }
     end
 
@@ -197,8 +194,7 @@ class ClientTest < Raygun::UnitTest
             stackTrace: [
               { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" },
               { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run"}
-            ],
-            innerError: {},
+            ]
           },
           userCustomData: {},
           tags:           ["test"],


### PR DESCRIPTION
I think it should be it to provide nested error information, as #70 suggests.

I am just not sure if there is any reason to watch for closed structures. In that case it would also be required to track visited errors.
