### PR TITLE
Allow Filtering of Custom_Data

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -135,9 +135,14 @@ module Raygun
         end
       end
 
+      def filter_custom_data(env)
+        params = env.delete(:custom_data) || {}
+        filter_params(params, env["action_dispatch.parameter_filter"])
+      end
+
       # see http://raygun.io/raygun-providers/rest-json-api?v=1
       def build_payload_hash(exception_instance, env = {})
-        custom_data = env.delete(:custom_data) || {}
+        custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
         tags << rack_env if rack_env_present?
 
@@ -187,7 +192,7 @@ module Raygun
           when Hash
             filter_params_with_array(v, filter_keys)
           else
-            filter_keys.include?(k) ? "[FILTERED]" : v
+            filter_keys.include?(k.to_s) ? "[FILTERED]" : v
           end
           result
         end


### PR DESCRIPTION
Currently `custom_data` is not filtered when it is sent from the provider.  

This pull request modifies portions of the `lib/raygun/client.rb` to apply the same filtering process used for `raw_data` to `custom_data` via a new method:  `filter_custom_data`.  This new method utilizes the same logic as `form_params` and handles the `custom_data = env.delete(:custom_data) that `build_payload_hash` had implemented previously.

A small change was also made to `filter_params_with_array` to ensure that all values would be compared as strings, as opposed to symbols which `custom_data` was passing in.

Further backstory and reasoning sent via email to Nik.