### PR TITLE
Prevent logging of password confirmations

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -192,7 +192,7 @@ module Raygun
           when Hash
             filter_params_with_array(v, filter_keys)
           else
-            filter_keys.include?(k.to_s) ? "[FILTERED]" : v
+            filter_keys.any? { |fk| /#{fk}/i === k.to_s } ? "[FILTERED]" : v
           end
           result
         end


### PR DESCRIPTION
This change ensures that parameters such as `password_confirmation` are
not sent to the server.

Previously parameters were only filtered when their name exactly matched
a member of the `filter_parameters` list. The test
`test_filter_parameters_using_proc` in `client_test.rb` uses a custom
`Proc` to demonstrate filtering of all parameters starting with
'nsa_only'. This is a valid demonstration however the default
configuration for Rails applications uses a different code path not
containing the logic from that `Proc`.

A default configuration for Rails applications is something like the
following where the Raygun client inherits the filter list from Rails as
an array of Symbols. In most cases this will result in an Array
containing a single element `:password`.

```
config.filter_parameters = Rails.application.config.filter_parameters
```

This will trigger a code path running through the private client method
`filter_params_with_array` which as previously stated requires an exact
name match in order to filter the parameter.

In an attempt to remain consistent with Rails users' expectations and
without creating a hard dependency I have emulated ActionDispatch's
method of matching with a case insensitive regular
expression.