### PR TITLE
In tags, insert rails_env instead of rack_env if present

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -86,6 +86,14 @@ module Raygun
         !!ENV["RACK_ENV"]
       end
 
+      def rails_env
+        ENV["RAILS_ENV"]
+      end
+
+      def rails_env_present?
+        !!ENV["RAILS_ENV"]
+      end
+
       def request_information(env)
         return {} if env.nil? || env.empty?
         {
@@ -144,7 +152,12 @@ module Raygun
       def build_payload_hash(exception_instance, env = {})
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
-        tags << rack_env if rack_env_present?
+
+        if rails_env_present?
+          tags << rails_env
+        elsif rack_env_present?
+          tags << rack_env
+        end
 
         grouping_key = env.delete(:grouping_key)
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -82,16 +82,8 @@ module Raygun
         ENV["RACK_ENV"]
       end
 
-      def rack_env_present?
-        !!ENV["RACK_ENV"]
-      end
-
       def rails_env
         ENV["RAILS_ENV"]
-      end
-
-      def rails_env_present?
-        !!ENV["RAILS_ENV"]
       end
 
       def request_information(env)
@@ -153,11 +145,7 @@ module Raygun
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
 
-        if rails_env_present?
-          tags << rails_env
-        elsif rack_env_present?
-          tags << rack_env
-        end
+        tags << rails_env || rack_env
 
         grouping_key = env.delete(:grouping_key)
 
@@ -167,7 +155,7 @@ module Raygun
             client:         client_details,
             error:          error_details(exception_instance),
             userCustomData: Raygun.configuration.custom_data.merge(custom_data),
-            tags:           Raygun.configuration.tags.concat(tags).uniq,
+            tags:           Raygun.configuration.tags.concat(tags).compact.uniq,
             request:        request_information(env)
         }
 


### PR DESCRIPTION
Rails env should be preferred over rack env if present. We have several applications with the same rack env but with a specific Rails env so the gem is adding the wrong environment tag (rack env instead of rails env).