### PR TITLE
Make optional environment tags

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -86,6 +86,14 @@ module Raygun
         !!ENV["RACK_ENV"]
       end
 
+      def rails_env
+        ENV["RAILS_ENV"]
+      end
+
+      def rails_env_present?
+        !!ENV["RAILS_ENV"]
+      end
+
       def request_information(env)
         return {} if env.nil? || env.empty?
         {
@@ -144,7 +152,12 @@ module Raygun
       def build_payload_hash(exception_instance, env = {})
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
-        tags << rack_env if rack_env_present?
+
+        if rails_env_present?
+          tags << rails_env
+        elsif rack_env_present?
+          tags << rack_env
+        end
 
         grouping_key = env.delete(:grouping_key)
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -145,7 +145,9 @@ module Raygun
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
 
-        tags << rails_env || rack_env
+        if Raygun.configuration.auto_tag_environment
+          tags << rails_env || rack_env
+        end
 
         grouping_key = env.delete(:grouping_key)
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -82,16 +82,8 @@ module Raygun
         ENV["RACK_ENV"]
       end
 
-      def rack_env_present?
-        !!ENV["RACK_ENV"]
-      end
-
       def rails_env
         ENV["RAILS_ENV"]
-      end
-
-      def rails_env_present?
-        !!ENV["RAILS_ENV"]
       end
 
       def request_information(env)
@@ -153,11 +145,7 @@ module Raygun
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
 
-        if rails_env_present?
-          tags << rails_env
-        elsif rack_env_present?
-          tags << rack_env
-        end
+        tags << rails_env || rack_env
 
         grouping_key = env.delete(:grouping_key)
 
@@ -167,7 +155,7 @@ module Raygun
             client:         client_details,
             error:          error_details(exception_instance),
             userCustomData: Raygun.configuration.custom_data.merge(custom_data),
-            tags:           Raygun.configuration.tags.concat(tags).uniq,
+            tags:           Raygun.configuration.tags.concat(tags).compact.uniq,
             request:        request_information(env)
         }
 

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -47,6 +47,9 @@ module Raygun
     # Hash of proxy settings - :address, :port (defaults to 80), :username and :password (both default to nil)
     config_option :proxy_settings
 
+    # Should we add automatically add the application environment to the tags array
+    config_option :auto_tag_environment
+
     # Exception classes to ignore by default
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
@@ -73,7 +76,8 @@ module Raygun
         affected_user_method:             :current_user,
         affected_user_identifier_methods: [ :email, :username, :id ],
         filter_parameters:                DEFAULT_FILTER_PARAMETERS,
-        proxy_settings:                   {}
+        proxy_settings:                   {},
+        auto_tag_environment:             true
       })
     end
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -76,4 +76,14 @@ class ConfigurationTest < Raygun::UnitTest
     Raygun.configuration.filter_parameters = nil
   end
 
+  def test_auto_tag_environment
+    assert_equal(['test'], Raygun::Client.new.send(:build_payload_hash,TestException.new)[:details][:tags])
+
+    Raygun.configuration.auto_tag_environment = false
+
+    assert_equal([], Raygun::Client.new.send(:build_payload_hash,TestException.new)[:details][:tags])
+  ensure
+    Raygun.configuration.auto_tag_environment = true
+  end
+
 end


### PR DESCRIPTION
### Description ###
Allow to deactivate auto adding the environment in the tags.

Based on https://github.com/MindscapeHQ/raygun4ruby/pull/96