### PR TITLE
Allow to use httparty 0.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ script:
   - bundle exec rake
 
 rvm:
- - 1.9.3
  - 2.0.0
  - 2.2.5
- - 2.3.1
+ - 2.3.3
+ - 2.4.0
 
 gemfile:
   - Gemfile

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "httparty", "~> 0.13.7"
+  spec.add_runtime_dependency "httparty", "> 0.13.7"
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "rack"
 


### PR DESCRIPTION
httparty 0.13.7 requires json 1.8, and json 1.8 not working with ruby 2.4