### PR TITLE
Add option to filter entire payload using whitelist approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 1.2.0 (09/03/2017)
+
+Features:
+  - Added two new configuration options, `filter_payload_with_whitelist` and `whitelist_payload_shape`
+    - See [README.md](https://github.com/MindscapeHQ/raygun4ruby#filtering-the-payload-by-whitelist) for an example of how to use them

--- a/README.md
+++ b/README.md
@@ -91,6 +91,42 @@ Raygun.setup do |config|
 end
 ```
 
+### Filtering the payload by whitelist
+
+As an alternative to the above, you can also opt-in to the keys/values to be sent to Raygun by providing a specific whitelist of the keys you want to transmit.
+
+This disables the blacklist filtering above (`filter_parameters`), and is applied to the entire payload (error, request, environment and custom data included), not just the request parameters.
+
+In order to opt-in to this feature, set `filter_payload_with_whitelist` to `true`, and choose what keys you want (the default is below which is to allow everything through):
+
+```ruby
+Raygun.setup do |config|
+  config.api_key = "YOUR_RAYGUN_API_KEY"
+  config.filter_payload_with_whitelist = true
+
+  config.whitelist_payload_keys = [
+    :machineName, :version,
+    :error, :className, :message, :stackTrace,
+    :userCustomData, :tags,
+    :request, :hostName, :url, :httpMethod, :iPAddress, :queryString, :headers, :form, :rawData
+  ]
+end
+```
+
+Alternatively, provide a Proc to filter the payload using your own logic:
+
+```ruby
+Raygun.setup do |config|
+  config.api_key = "YOUR_RAYGUN_API_KEY"
+  config.filter_payload_with_whitelist = true
+
+  config.whitelist_payload_keys do |payload|
+    # Return the payload mutated into your desired form
+    payload
+  end
+end
+```
+
 ### Custom User Data
 Custom data can be added to `track_exception` by passing a custom_data key in the second parameter hash.
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Raygun4Ruby can track errors from Sidekiq (2.x or 3+). All you need to do is add
 
 Either in your Raygun initializer or wherever else takes your fancy :)
 
+### Other Configuration options
+
+For a complete list of configuration options see the [configuration.rb](https://github.com/MindscapeHQ/raygun4ruby/blob/master/lib/raygun/configuration.rb) file
+
 ## Found a bug?
 
 Oops! Just let us know by opening an Issue on Github.

--- a/README.md
+++ b/README.md
@@ -97,19 +97,30 @@ As an alternative to the above, you can also opt-in to the keys/values to be sen
 
 This disables the blacklist filtering above (`filter_parameters`), and is applied to the entire payload (error, request, environment and custom data included), not just the request parameters.
 
-In order to opt-in to this feature, set `filter_payload_with_whitelist` to `true`, and choose what keys you want (the default is below which is to allow everything through):
+In order to opt-in to this feature, set `filter_payload_with_whitelist` to `true`, and specify a shape of what keys you want (the default is below which is to allow everything through, this also means that the query parameters filtered out by default like password, creditcard etc will not be unless changed):
 
 ```ruby
 Raygun.setup do |config|
   config.api_key = "YOUR_RAYGUN_API_KEY"
   config.filter_payload_with_whitelist = true
 
-  config.whitelist_payload_keys = [
-    :machineName, :version,
-    :error, :className, :message, :stackTrace,
-    :userCustomData, :tags,
-    :request, :hostName, :url, :httpMethod, :iPAddress, :queryString, :headers, :form, :rawData
-  ]
+  config.whitelist_payload_shape = {
+      machineName: true,
+      version: true,
+      error: true,
+      userCustomData: true,
+      tags: true,
+      request: {
+        hostName: true,
+        url: true,
+        httpMethod: true,
+        iPAddress: true,
+        queryString: true,
+        headers: true,
+        form: {}, # Set to empty hash so that it doesn't just filter out the whole thing, but instead filters out each individual param
+        rawData: true
+      }
+    }
 end
 ```
 

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -11,6 +11,10 @@ require "raygun/client"
 require "raygun/middleware/rack_exception_interceptor"
 require "raygun/testable"
 require "raygun/railtie" if defined?(Rails)
+begin
+  require "pry"
+rescue LoadError
+end
 
 module Raygun
 

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -10,6 +10,7 @@ require "raygun/configuration"
 require "raygun/client"
 require "raygun/middleware/rack_exception_interceptor"
 require "raygun/testable"
+require "raygun/services/apply_whitelist_filter_to_payload"
 require "raygun/railtie" if defined?(Rails)
 begin
   require "pry"

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -145,7 +145,8 @@ module Raygun
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
 
-        tags << rails_env || rack_env
+        tags << rails_env if rails_env
+        tags << rack_env if rack_env
 
         grouping_key = env.delete(:grouping_key)
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -195,10 +195,10 @@ module Raygun
       end
 
       def filter_payload(payload_hash)
-        if Raygun.configuration.filter_parameters.is_a?(Proc)
-          filter_hash_with_proc(payload_hash, Raygun.configuration.filter_parameters)
+        if Raygun.configuration.whitelist_payload_keys.is_a?(Proc)
+          filter_hash_with_proc(payload_hash, Raygun.configuration.whitelist_payload_keys)
         else
-          filter_keys = Raygun.configuration.filter_parameters.map(&:to_s)
+          filter_keys = Raygun.configuration.whitelist_payload_keys.map(&:to_s)
           filter_payload_with_array(payload_hash, filter_keys, {})
         end
       end

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -167,7 +167,7 @@ module Raygun
 
         error_details.merge!(user: user_information(env)) if affected_user_present?(env)
 
-        if Raygun.configuration.filter_whitelists_all
+        if Raygun.configuration.filter_payload_with_whitelist
           error_details = filter_payload(error_details)
           error_details[:client] = client_details
         end
@@ -183,7 +183,7 @@ module Raygun
       end
 
       def filter_params(params_hash, extra_filter_keys = nil)
-        if Raygun.configuration.filter_whitelists_all
+        if Raygun.configuration.filter_payload_with_whitelist
           params_hash
         end
         if Raygun.configuration.filter_parameters.is_a?(Proc)

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -166,9 +166,7 @@ module Raygun
 
         if Raygun.configuration.filter_whitelists_all
           error_details = filter_payload(error_details)
-          if error_details[:client] === '[FILTERED]'
-            error_details[:client] = client_details
-          end
+          error_details[:client] = client_details
         end
 
         {

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -183,6 +183,9 @@ module Raygun
       end
 
       def filter_params(params_hash, extra_filter_keys = nil)
+        if Raygun.configuration.filter_whitelists_all
+          params_hash
+        end
         if Raygun.configuration.filter_parameters.is_a?(Proc)
           filter_hash_with_proc(params_hash, Raygun.configuration.filter_parameters)
         else

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -164,6 +164,8 @@ module Raygun
 
         error_details.merge!(user: user_information(env)) if affected_user_present?(env)
 
+        error_details = filter_hash(error_details, Raygun.configuration.filter_parameters) if Raygun.configuration.filter_whitelists_all
+
         {
           occurredOn: Time.now.utc.iso8601,
           details:    error_details

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -217,10 +217,10 @@ module Raygun
       end
 
       def filter_payload_with_array(params_hash, filter_keys)
-        # Recursive filtering of (nested) hashes, but will filter branch nodes
-        # instead of just leaves as filter_params_with_array does
+        # Whitelist filtering of (nested) hashes, only including filter_keys
+        # that are defined in filter_parameters, recursively for both branch and leaf nodes
         (params_hash || {}).inject({}) do |result, (k, v)|
-          if filter_keys.any? { |fk| /#{fk}/i === k.to_s }
+          if !filter_keys.any? { |fk| /#{fk}/i === k.to_s }
             result[k] = "[FILTERED]"
           elsif v.class == Hash
             result[k] = filter_payload_with_array(v, filter_keys)

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -145,8 +145,11 @@ module Raygun
         custom_data = filter_custom_data(env) || {}
         tags = env.delete(:tags) || []
 
-        tags << rails_env if rails_env
-        tags << rack_env if rack_env
+        if rails_env
+          tags << rails_env
+        else
+          tags << rack_env
+        end
 
         grouping_key = env.delete(:grouping_key)
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -255,7 +255,7 @@ module Raygun
 
       def is_whitelisted_recursive(whitelist, key)
         always_whitelisted_keys = [:headers, :queryString]
-        
+
         is_whitelisted(always_whitelisted_keys, key) && is_whitelisted(whitelist, key)
       end
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -116,7 +116,7 @@ module Raygun
 
       def form_params(env)
         params = action_dispatch_params(env) || rack_params(env) || {}
-        filter_hash(params, env["action_dispatch.parameter_filter"])
+        filter_params(params, env["action_dispatch.parameter_filter"])
       end
 
       def action_dispatch_params(env)
@@ -137,7 +137,7 @@ module Raygun
 
       def filter_custom_data(env)
         params = env.delete(:custom_data) || {}
-        filter_hash(params, env["action_dispatch.parameter_filter"])
+        filter_params(params, env["action_dispatch.parameter_filter"])
       end
 
       # see http://raygun.io/raygun-providers/rest-json-api?v=1
@@ -189,12 +189,12 @@ module Raygun
         proc.call(hash)
       end
 
-      def filter_hash_with_array(hash, filter_keys)
+      def filter_params_with_array(params_hash, filter_keys)
         # Recursive filtering of (nested) hashes
-        (hash || {}).inject({}) do |result, (k, v)|
+        (params_hash || {}).inject({}) do |result, (k, v)|
           result[k] = case v
           when Hash
-            filter_hash_with_array(v, filter_keys)
+            filter_params_with_array(v, filter_keys)
           else
             filter_keys.any? { |fk| /#{fk}/i === k.to_s } ? "[FILTERED]" : v
           end

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -164,7 +164,12 @@ module Raygun
 
         error_details.merge!(user: user_information(env)) if affected_user_present?(env)
 
-        error_details = filter_payload(error_details) if Raygun.configuration.filter_whitelists_all
+        if Raygun.configuration.filter_whitelists_all
+          error_details = filter_payload(error_details)
+          if error_details[:client] === '[FILTERED]'
+            error_details[:client] = client_details
+          end
+        end
 
         {
           occurredOn: Time.now.utc.iso8601,

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -26,7 +26,7 @@ module Raygun
     # Tags to send with each exception
     config_option :tags
 
-    # Logger to use when if we find an exception :)
+    # Logger to use when we find an exception :)
     config_option :logger
 
     # Should we actually report exceptions to Raygun? (Usually disabled in Development mode, for instance)
@@ -44,8 +44,10 @@ module Raygun
     # Which parameter keys should we filter out by default?
     config_option :filter_parameters
 
+    # Should we switch to a white listing mode for keys instead of the default blacklist?
     config_option :filter_payload_with_whitelist
 
+    # If :filter_payload_with_whitelist is true, which keys should we whitelist?
     config_option :whitelist_payload_keys
 
     # Hash of proxy settings - :address, :port (defaults to 80), :username and :password (both default to nil)

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -44,7 +44,7 @@ module Raygun
     # Which parameter keys should we filter out by default?
     config_option :filter_parameters
 
-    config_option :filter_whitelists_all
+    config_option :filter_payload_with_whitelist
 
     # Hash of proxy settings - :address, :port (defaults to 80), :username and :password (both default to nil)
     config_option :proxy_settings
@@ -75,7 +75,7 @@ module Raygun
         affected_user_method:             :current_user,
         affected_user_identifier_methods: [ :email, :username, :id ],
         filter_parameters:                DEFAULT_FILTER_PARAMETERS,
-        filter_whitelists_all:            false,
+        filter_payload_with_whitelist:    false,
         proxy_settings:                   {}
       })
     end

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -44,6 +44,8 @@ module Raygun
     # Which parameter keys should we filter out by default?
     config_option :filter_parameters
 
+    config_option :filter_whitelists_all
+
     # Hash of proxy settings - :address, :port (defaults to 80), :username and :password (both default to nil)
     config_option :proxy_settings
 
@@ -73,6 +75,7 @@ module Raygun
         affected_user_method:             :current_user,
         affected_user_identifier_methods: [ :email, :username, :id ],
         filter_parameters:                DEFAULT_FILTER_PARAMETERS,
+        filter_whitelist_all:             false,
         proxy_settings:                   {}
       })
     end

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -46,6 +46,8 @@ module Raygun
 
     config_option :filter_payload_with_whitelist
 
+    config_option :whitelist_payload_keys
+
     # Hash of proxy settings - :address, :port (defaults to 80), :username and :password (both default to nil)
     config_option :proxy_settings
 
@@ -60,6 +62,28 @@ module Raygun
                       'Mongoid::Errors::DocumentNotFound']
 
     DEFAULT_FILTER_PARAMETERS = [ :password, :card_number, :cvv ]
+
+
+
+    DEFAULT_WHITELIST_PAYLOAD_KEYS = [
+      :machineName,
+      :version,
+      :error,
+      :className,
+      :message,
+      :stackTrace,
+      :userCustomData,
+      :tags,
+      :request,
+      :hostName,
+      :url,
+      :httpMethod,
+      :iPAddress,
+      :queryString,
+      :headers,
+      :form,
+      :rawData
+    ]
 
     attr_reader :defaults
 
@@ -76,6 +100,7 @@ module Raygun
         affected_user_identifier_methods: [ :email, :username, :id ],
         filter_parameters:                DEFAULT_FILTER_PARAMETERS,
         filter_payload_with_whitelist:    false,
+        whitelist_payload_keys:           DEFAULT_WHITELIST_PAYLOAD_KEYS,
         proxy_settings:                   {}
       })
     end
@@ -99,6 +124,11 @@ module Raygun
     def filter_parameters(&filter_proc)
       set_value(:filter_parameters, filter_proc) if block_given?
       read_value(:filter_parameters)
+    end
+
+    def whitelist_payload_keys(&filter_proc)
+      set_value(:whitelist_payload_keys, filter_proc) if block_given?
+      read_value(:whitelist_payload_keys)
     end
 
     private

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -74,7 +74,7 @@ module Raygun
       iPAddress: true,
       queryString: true,
       headers: true,
-      form: true,
+      form: {}, # Set to empty hash so that it doesn't just filter out the whole thing, but instead filters out each individual param
       rawData: true
     }
     DEFAULT_WHITELIST_PAYLOAD_SHAPE = {

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -48,7 +48,7 @@ module Raygun
     config_option :filter_payload_with_whitelist
 
     # If :filter_payload_with_whitelist is true, which keys should we whitelist?
-    config_option :whitelist_payload_keys
+    config_option :whitelist_payload_shape
 
     # Hash of proxy settings - :address, :port (defaults to 80), :username and :password (both default to nil)
     config_option :proxy_settings
@@ -67,25 +67,24 @@ module Raygun
 
 
 
-    DEFAULT_WHITELIST_PAYLOAD_KEYS = [
-      :machineName,
-      :version,
-      :error,
-      :className,
-      :message,
-      :stackTrace,
-      :userCustomData,
-      :tags,
-      :request,
-      :hostName,
-      :url,
-      :httpMethod,
-      :iPAddress,
-      :queryString,
-      :headers,
-      :form,
-      :rawData
-    ]
+    DEFAULT_WHITELIST_PAYLOAD_SHAPE_REQUEST = {
+      hostName: true,
+      url: true,
+      httpMethod: true,
+      iPAddress: true,
+      queryString: true,
+      headers: true,
+      form: true,
+      rawData: true
+    }
+    DEFAULT_WHITELIST_PAYLOAD_SHAPE = {
+      machineName: true,
+      version: true,
+      error: true,
+      userCustomData: true,
+      tags: true,
+      request: DEFAULT_WHITELIST_PAYLOAD_SHAPE_REQUEST
+    }
 
     attr_reader :defaults
 
@@ -102,7 +101,7 @@ module Raygun
         affected_user_identifier_methods: [ :email, :username, :id ],
         filter_parameters:                DEFAULT_FILTER_PARAMETERS,
         filter_payload_with_whitelist:    false,
-        whitelist_payload_keys:           DEFAULT_WHITELIST_PAYLOAD_KEYS,
+        whitelist_payload_shape:          DEFAULT_WHITELIST_PAYLOAD_SHAPE,
         proxy_settings:                   {}
       })
     end
@@ -128,9 +127,9 @@ module Raygun
       read_value(:filter_parameters)
     end
 
-    def whitelist_payload_keys(&filter_proc)
-      set_value(:whitelist_payload_keys, filter_proc) if block_given?
-      read_value(:whitelist_payload_keys)
+    def whitelist_payload_shape(&filter_proc)
+      set_value(:whitelist_payload_shape, filter_proc) if block_given?
+      read_value(:whitelist_payload_shape)
     end
 
     private

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -75,7 +75,7 @@ module Raygun
         affected_user_method:             :current_user,
         affected_user_identifier_methods: [ :email, :username, :id ],
         filter_parameters:                DEFAULT_FILTER_PARAMETERS,
-        filter_whitelist_all:             false,
+        filter_whitelists_all:            false,
         proxy_settings:                   {}
       })
     end

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -65,8 +65,6 @@ module Raygun
 
     DEFAULT_FILTER_PARAMETERS = [ :password, :card_number, :cvv ]
 
-
-
     DEFAULT_WHITELIST_PAYLOAD_SHAPE_REQUEST = {
       hostName: true,
       url: true,
@@ -76,7 +74,7 @@ module Raygun
       headers: true,
       form: {}, # Set to empty hash so that it doesn't just filter out the whole thing, but instead filters out each individual param
       rawData: true
-    }
+    }.freeze
     DEFAULT_WHITELIST_PAYLOAD_SHAPE = {
       machineName: true,
       version: true,
@@ -84,7 +82,7 @@ module Raygun
       userCustomData: true,
       tags: true,
       request: DEFAULT_WHITELIST_PAYLOAD_SHAPE_REQUEST
-    }
+    }.freeze
 
     attr_reader :defaults
 

--- a/lib/raygun/services/apply_whitelist_filter_to_payload.rb
+++ b/lib/raygun/services/apply_whitelist_filter_to_payload.rb
@@ -1,18 +1,22 @@
-class ApplyWhitelistFilterToPayload
-  def call(whitelist, payload)
-    filter_hash(whitelist, payload)
-  end
-
-  private
-
-  def filter_hash(whitelist, hash)
-    hash.each do |k, v|
-      unless whitelist && (whitelist[k] || whitelist[k.to_sym])
-        hash[k] = '[FILTERED]'
+module Raygun
+  module Services
+    class ApplyWhitelistFilterToPayload
+      def call(whitelist, payload)
+        filter_hash(whitelist, payload)
       end
 
-      if v.is_a?(Hash) && whitelist[k].is_a?(Hash)
-        filter_hash(whitelist[k], v)
+      private
+
+      def filter_hash(whitelist, hash)
+        hash.each do |k, v|
+          unless whitelist && (whitelist[k] || whitelist[k.to_sym])
+            hash[k] = '[FILTERED]'
+          end
+
+          if v.is_a?(Hash) && whitelist[k].is_a?(Hash)
+            filter_hash(whitelist[k], v)
+          end
+        end
       end
     end
   end

--- a/lib/raygun/services/apply_whitelist_filter_to_payload.rb
+++ b/lib/raygun/services/apply_whitelist_filter_to_payload.rb
@@ -7,7 +7,7 @@ class ApplyWhitelistFilterToPayload
 
   def filter_hash(whitelist, hash)
     hash.each do |k, v|
-      unless whitelist && whitelist[k]
+      unless whitelist && (whitelist[k] || whitelist[k.to_sym])
         hash[k] = '[FILTERED]'
       end
 

--- a/lib/raygun/services/apply_whitelist_filter_to_payload.rb
+++ b/lib/raygun/services/apply_whitelist_filter_to_payload.rb
@@ -1,0 +1,19 @@
+class ApplyWhitelistFilterToPayload
+  def call(whitelist, payload)
+    filter_hash(whitelist, payload)
+  end
+
+  private
+
+  def filter_hash(whitelist, hash)
+    hash.each do |k, v|
+      unless whitelist && whitelist[k]
+        hash.delete(k)
+      end
+
+      if v.is_a?(Hash) && whitelist[k].is_a?(Hash)
+        filter_hash(whitelist[k], v)
+      end
+    end
+  end
+end

--- a/lib/raygun/services/apply_whitelist_filter_to_payload.rb
+++ b/lib/raygun/services/apply_whitelist_filter_to_payload.rb
@@ -8,7 +8,7 @@ class ApplyWhitelistFilterToPayload
   def filter_hash(whitelist, hash)
     hash.each do |k, v|
       unless whitelist && whitelist[k]
-        hash.delete(k)
+        hash[k] = '[FILTERED]'
       end
 
       if v.is_a?(Hash) && whitelist[k].is_a?(Hash)

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "1.1.12"
+  VERSION = "1.2.0"
 end

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "resque"
   spec.add_development_dependency "sidekiq", [">= 3", "< 3.2.2"]
   spec.add_development_dependency "mocha"
+  spec.add_development_dependency "pry"
 end

--- a/specs/services/apply_whitelist_filter_to_payload_spec.rb
+++ b/specs/services/apply_whitelist_filter_to_payload_spec.rb
@@ -10,7 +10,7 @@ describe ApplyWhitelistFilterToPayload do
       { foo: 1, bar: 2 }
     end
     let(:expected) do
-      { foo: 1 }
+      { foo: 1 , bar: '[FILTERED]'}
     end
 
     it "filters out keys that are not present in the shape" do
@@ -46,7 +46,8 @@ describe ApplyWhitelistFilterToPayload do
     let(:expected) {{
       foo: 1,
       bar: {
-        baz: 2
+        baz: 2,
+        qux: '[FILTERED]'
       }
     }}
 
@@ -67,7 +68,7 @@ describe ApplyWhitelistFilterToPayload do
       shape = {
         foo: true
       }
-      expected.delete(:bar)
+      expected[:bar] = "[FILTERED]"
 
       new_payload = service.call(shape, payload)
 
@@ -79,6 +80,7 @@ describe ApplyWhitelistFilterToPayload do
         bar: true
       }
       expected = {
+        foo: '[FILTERED]',
         bar: {
           baz: 2,
           qux: 3
@@ -96,7 +98,8 @@ describe ApplyWhitelistFilterToPayload do
         bar: false
       }
       expected = {
-        foo: 1
+        foo: 1,
+        bar: '[FILTERED]'
       }
 
       new_payload = service.call(shape, payload)
@@ -196,18 +199,25 @@ describe ApplyWhitelistFilterToPayload do
         queryString: {
           param1: "1",
           param2: "2",
+          param3: '[FILTERED]'
         },
         headers: {
           "Host"=>"localhost:3000",
           "Connection"=>"keep-alive",
           "Upgrade-Insecure_requests"=>"1",
+          "User-Agent" => "[FILTERED]",
           "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+          "Accept-Encoding" => "[FILTERED]",
+          "Accept-Language" => "[FILTERED]",
+          "Version" => "[FILTERED]"
         },
         form: {
           controller: "home",
+          action: "[FILTERED]"
         },
         rawData: {
           controller: "home",
+          action: "[FILTERED]"
         }
       }
     }

--- a/specs/services/apply_whitelist_filter_to_payload_spec.rb
+++ b/specs/services/apply_whitelist_filter_to_payload_spec.rb
@@ -2,248 +2,252 @@ require "minitest/autorun"
 require "minitest/pride"
 require_relative "../../lib/raygun"
 
-describe ApplyWhitelistFilterToPayload do
-  let(:service) { ApplyWhitelistFilterToPayload.new }
+module Raygun
+  module Services
+    describe ApplyWhitelistFilterToPayload do
+      let(:service) { ApplyWhitelistFilterToPayload.new }
 
-  describe "top level keys" do
-    let(:payload) do
-      { foo: 1, bar: 2 }
-    end
-    let(:expected) do
-      { foo: 1 , bar: '[FILTERED]'}
-    end
+      describe "top level keys" do
+        let(:payload) do
+          { foo: 1, bar: 2 }
+        end
+        let(:expected) do
+          { foo: 1 , bar: '[FILTERED]'}
+        end
 
-    it "filters out keys that are not present in the shape" do
-      shape = {
-        foo: true
-      }
+        it "filters out keys that are not present in the shape" do
+          shape = {
+            foo: true
+          }
 
-      new_payload = service.call(shape, payload)
+          new_payload = service.call(shape, payload)
 
-      new_payload.must_equal(expected)
-    end
+          new_payload.must_equal(expected)
+        end
 
-    it "filters out keys that are set to false" do
-      shape = {
-        foo: true,
-        bar: false
-      }
+        it "filters out keys that are set to false" do
+          shape = {
+            foo: true,
+            bar: false
+          }
 
-      new_payload = service.call(shape, payload)
+          new_payload = service.call(shape, payload)
 
-      new_payload.must_equal(expected)
-    end
-  end
+          new_payload.must_equal(expected)
+        end
+      end
 
-  describe "nested hashes" do
-    let(:payload) {{
-      foo: 1,
-      bar: {
-        baz: 2,
-        qux: 3
-      }
-    }}
-    let(:expected) {{
-      foo: 1,
-      bar: {
-        baz: 2,
-        qux: '[FILTERED]'
-      }
-    }}
+      describe "nested hashes" do
+        let(:payload) {{
+          foo: 1,
+          bar: {
+            baz: 2,
+            qux: 3
+          }
+        }}
+        let(:expected) {{
+          foo: 1,
+          bar: {
+            baz: 2,
+            qux: '[FILTERED]'
+          }
+        }}
 
-    it "filters out keys in nested hashes" do
-      shape = {
-        foo: true,
-        bar: {
-          baz: true
+        it "filters out keys in nested hashes" do
+          shape = {
+            foo: true,
+            bar: {
+              baz: true
+            }
+          }
+
+          new_payload = service.call(shape, payload)
+
+          new_payload.must_equal(expected)
+        end
+
+        it "filters out a nested hash if the whitelist does not contain it" do
+          shape = {
+            foo: true
+          }
+          expected[:bar] = "[FILTERED]"
+
+          new_payload = service.call(shape, payload)
+
+          new_payload.must_equal(expected)
+        end
+
+        it "handles nested hashes when the whitelist is set to allow the whole hash" do
+          shape = {
+            bar: true
+          }
+          expected = {
+            foo: '[FILTERED]',
+            bar: {
+              baz: 2,
+              qux: 3
+            }
+          }
+
+          new_payload = service.call(shape, payload)
+
+          new_payload.must_equal(expected)
+        end
+
+        it "handles nested hashes when the whitelist is set to not allow the whole hash" do
+          shape = {
+            foo: true,
+            bar: false
+          }
+          expected = {
+            foo: 1,
+            bar: '[FILTERED]'
+          }
+
+          new_payload = service.call(shape, payload)
+
+          new_payload.must_equal(expected)
+        end
+      end
+
+      describe "string keys" do
+        it "handles the case where a payload key is a string and a whitelist key is a symbol" do
+          shape = {
+            foo: true
+          }
+          payload = {
+            "foo" => 1,
+            "bar" => 2
+          }
+          expected = {
+            "foo" => 1,
+            "bar" => '[FILTERED]'
+          }
+
+          new_payload = service.call(shape, payload)
+
+          new_payload.must_equal(expected)
+        end
+      end
+
+      it "handles a very complex shape" do
+        shape = {
+          machineName: true,
+          version: true,
+          client: true,
+          error: {
+            className: true,
+            message: true,
+            stackTrace: true
+          },
+          userCustomData: true,
+          tags: true,
+          request: {
+            hostName: true,
+            url: true,
+            httpMethod: true,
+            iPAddress: true,
+            queryString: {
+              param1: true,
+              param2: true,
+            },
+            headers: {
+              "Host" => true,
+              "Connection" => true,
+              "Upgrade-Insecure_requests" => true,
+              "User-Agent" => false,
+              "Accept" => true,
+            },
+            form: {
+              controller: true,
+              action: false
+            },
+            rawData: {
+              controller: true,
+              action: false
+            }
+          },
+          user: false,
         }
-      }
-
-      new_payload = service.call(shape, payload)
-
-      new_payload.must_equal(expected)
-    end
-
-    it "filters out a nested hash if the whitelist does not contain it" do
-      shape = {
-        foo: true
-      }
-      expected[:bar] = "[FILTERED]"
-
-      new_payload = service.call(shape, payload)
-
-      new_payload.must_equal(expected)
-    end
-
-    it "handles nested hashes when the whitelist is set to allow the whole hash" do
-      shape = {
-        bar: true
-      }
-      expected = {
-        foo: '[FILTERED]',
-        bar: {
-          baz: 2,
-          qux: 3
+        payload = {
+          machineName: "mindscapes-MacBook-Pro.local",
+          version: nil,
+          client: {name: "Raygun4Ruby Gem", version: "1.1.12", clientUrl: "https://github.com/MindscapeHQ/raygun4ruby"},
+          error: {className: "Exception", message: "foo", stackTrace: []},
+          userCustomData: {},
+          tags: ["development"],
+          request: {
+            hostName: "localhost",
+            url: "/make-me-an-error-charlie",
+            httpMethod: "GET",
+            iPAddress: "::1",
+            queryString: {
+              param1: "1",
+              param2: "2",
+              param3: "3",
+            },
+            headers: {
+              "Host"=>"localhost:3000",
+              "Connection"=>"keep-alive",
+              "Upgrade-Insecure_requests"=>"1",
+              "User-Agent"=> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+              "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+              "Accept-Encoding"=>"gzip, deflate, sdch, br",
+              "Accept-Language"=>"en-US,en;q=0.8",
+              "Version"=>"HTTP/1.1"
+            },
+            form: {
+              controller: "home",
+              action: "raise_error"
+            },
+            rawData: {
+              controller: "home",
+              action: "raise_error"
+            }
+          }
         }
-      }
-
-      new_payload = service.call(shape, payload)
-
-      new_payload.must_equal(expected)
-    end
-
-    it "handles nested hashes when the whitelist is set to not allow the whole hash" do
-      shape = {
-        foo: true,
-        bar: false
-      }
-      expected = {
-        foo: 1,
-        bar: '[FILTERED]'
-      }
-
-      new_payload = service.call(shape, payload)
-
-      new_payload.must_equal(expected)
-    end
-  end
-
-  describe "string keys" do
-    it "handles the case where a payload key is a string and a whitelist key is a symbol" do
-      shape = {
-        foo: true
-      }
-      payload = {
-        "foo" => 1,
-        "bar" => 2
-      }
-      expected = {
-        "foo" => 1,
-        "bar" => '[FILTERED]'
-      }
-
-      new_payload = service.call(shape, payload)
-
-      new_payload.must_equal(expected)
-    end
-  end
-
-  it "handles a very complex shape" do
-    shape = {
-      machineName: true,
-      version: true,
-      client: true,
-      error: {
-        className: true,
-        message: true,
-        stackTrace: true
-      },
-      userCustomData: true,
-      tags: true,
-      request: {
-        hostName: true,
-        url: true,
-        httpMethod: true,
-        iPAddress: true,
-        queryString: {
-          param1: true,
-          param2: true,
-        },
-        headers: {
-          "Host" => true,
-          "Connection" => true,
-          "Upgrade-Insecure_requests" => true,
-          "User-Agent" => false,
-          "Accept" => true,
-        },
-        form: {
-          controller: true,
-          action: false
-        },
-        rawData: {
-          controller: true,
-          action: false
+        expected = {
+          machineName: "mindscapes-MacBook-Pro.local",
+          version: nil,
+          client: {name: "Raygun4Ruby Gem", version: "1.1.12", clientUrl: "https://github.com/MindscapeHQ/raygun4ruby"},
+          error: {className: "Exception", message: "foo", stackTrace: []},
+          userCustomData: {},
+          tags: ["development"],
+          request: {
+            hostName: "localhost",
+            url: "/make-me-an-error-charlie",
+            httpMethod: "GET",
+            iPAddress: "::1",
+            queryString: {
+              param1: "1",
+              param2: "2",
+              param3: '[FILTERED]'
+            },
+            headers: {
+              "Host"=>"localhost:3000",
+              "Connection"=>"keep-alive",
+              "Upgrade-Insecure_requests"=>"1",
+              "User-Agent" => "[FILTERED]",
+              "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+              "Accept-Encoding" => "[FILTERED]",
+              "Accept-Language" => "[FILTERED]",
+              "Version" => "[FILTERED]"
+            },
+            form: {
+              controller: "home",
+              action: "[FILTERED]"
+            },
+            rawData: {
+              controller: "home",
+              action: "[FILTERED]"
+            }
+          }
         }
-      },
-      user: false,
-    }
-    payload = {
-      machineName: "mindscapes-MacBook-Pro.local",
-      version: nil,
-      client: {name: "Raygun4Ruby Gem", version: "1.1.12", clientUrl: "https://github.com/MindscapeHQ/raygun4ruby"},
-      error: {className: "Exception", message: "foo", stackTrace: []},
-      userCustomData: {},
-      tags: ["development"],
-      request: {
-        hostName: "localhost",
-        url: "/make-me-an-error-charlie",
-        httpMethod: "GET",
-        iPAddress: "::1",
-        queryString: {
-          param1: "1",
-          param2: "2",
-          param3: "3",
-        },
-        headers: {
-          "Host"=>"localhost:3000",
-          "Connection"=>"keep-alive",
-          "Upgrade-Insecure_requests"=>"1",
-          "User-Agent"=> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
-          "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-          "Accept-Encoding"=>"gzip, deflate, sdch, br",
-          "Accept-Language"=>"en-US,en;q=0.8",
-          "Version"=>"HTTP/1.1"
-        },
-        form: {
-          controller: "home",
-          action: "raise_error"
-        },
-        rawData: {
-          controller: "home",
-          action: "raise_error"
-        }
-      }
-    }
-    expected = {
-      machineName: "mindscapes-MacBook-Pro.local",
-      version: nil,
-      client: {name: "Raygun4Ruby Gem", version: "1.1.12", clientUrl: "https://github.com/MindscapeHQ/raygun4ruby"},
-      error: {className: "Exception", message: "foo", stackTrace: []},
-      userCustomData: {},
-      tags: ["development"],
-      request: {
-        hostName: "localhost",
-        url: "/make-me-an-error-charlie",
-        httpMethod: "GET",
-        iPAddress: "::1",
-        queryString: {
-          param1: "1",
-          param2: "2",
-          param3: '[FILTERED]'
-        },
-        headers: {
-          "Host"=>"localhost:3000",
-          "Connection"=>"keep-alive",
-          "Upgrade-Insecure_requests"=>"1",
-          "User-Agent" => "[FILTERED]",
-          "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
-          "Accept-Encoding" => "[FILTERED]",
-          "Accept-Language" => "[FILTERED]",
-          "Version" => "[FILTERED]"
-        },
-        form: {
-          controller: "home",
-          action: "[FILTERED]"
-        },
-        rawData: {
-          controller: "home",
-          action: "[FILTERED]"
-        }
-      }
-    }
 
-    new_payload = service.call(shape, payload)
+        new_payload = service.call(shape, payload)
 
-    new_payload.must_equal(expected)
+        new_payload.must_equal(expected)
+      end
+    end
   end
 end

--- a/specs/services/apply_whitelist_filter_to_payload_spec.rb
+++ b/specs/services/apply_whitelist_filter_to_payload_spec.rb
@@ -108,6 +108,26 @@ describe ApplyWhitelistFilterToPayload do
     end
   end
 
+  describe "string keys" do
+    it "handles the case where a payload key is a string and a whitelist key is a symbol" do
+      shape = {
+        foo: true
+      }
+      payload = {
+        "foo" => 1,
+        "bar" => 2
+      }
+      expected = {
+        "foo" => 1,
+        "bar" => '[FILTERED]'
+      }
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+  end
+
   it "handles a very complex shape" do
     shape = {
       machineName: true,

--- a/specs/services/apply_whitelist_filter_to_payload_spec.rb
+++ b/specs/services/apply_whitelist_filter_to_payload_spec.rb
@@ -1,0 +1,219 @@
+require "minitest/autorun"
+require "minitest/pride"
+require_relative "../../lib/raygun"
+
+describe ApplyWhitelistFilterToPayload do
+  let(:service) { ApplyWhitelistFilterToPayload.new }
+
+  describe "top level keys" do
+    let(:payload) do
+      { foo: 1, bar: 2 }
+    end
+    let(:expected) do
+      { foo: 1 }
+    end
+
+    it "filters out keys that are not present in the shape" do
+      shape = {
+        foo: true
+      }
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+
+    it "filters out keys that are set to false" do
+      shape = {
+        foo: true,
+        bar: false
+      }
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+  end
+
+  describe "nested hashes" do
+    let(:payload) {{
+      foo: 1,
+      bar: {
+        baz: 2,
+        qux: 3
+      }
+    }}
+    let(:expected) {{
+      foo: 1,
+      bar: {
+        baz: 2
+      }
+    }}
+
+    it "filters out keys in nested hashes" do
+      shape = {
+        foo: true,
+        bar: {
+          baz: true
+        }
+      }
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+
+    it "filters out a nested hash if the whitelist does not contain it" do
+      shape = {
+        foo: true
+      }
+      expected.delete(:bar)
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+
+    it "handles nested hashes when the whitelist is set to allow the whole hash" do
+      shape = {
+        bar: true
+      }
+      expected = {
+        bar: {
+          baz: 2,
+          qux: 3
+        }
+      }
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+
+    it "handles nested hashes when the whitelist is set to not allow the whole hash" do
+      shape = {
+        foo: true,
+        bar: false
+      }
+      expected = {
+        foo: 1
+      }
+
+      new_payload = service.call(shape, payload)
+
+      new_payload.must_equal(expected)
+    end
+  end
+
+  it "handles a very complex shape" do
+    shape = {
+      machineName: true,
+      version: true,
+      client: true,
+      error: {
+        className: true,
+        message: true,
+        stackTrace: true
+      },
+      userCustomData: true,
+      tags: true,
+      request: {
+        hostName: true,
+        url: true,
+        httpMethod: true,
+        iPAddress: true,
+        queryString: {
+          param1: true,
+          param2: true,
+        },
+        headers: {
+          "Host" => true,
+          "Connection" => true,
+          "Upgrade-Insecure_requests" => true,
+          "User-Agent" => false,
+          "Accept" => true,
+        },
+        form: {
+          controller: true,
+          action: false
+        },
+        rawData: {
+          controller: true,
+          action: false
+        }
+      },
+      user: false,
+    }
+    payload = {
+      machineName: "mindscapes-MacBook-Pro.local",
+      version: nil,
+      client: {name: "Raygun4Ruby Gem", version: "1.1.12", clientUrl: "https://github.com/MindscapeHQ/raygun4ruby"},
+      error: {className: "Exception", message: "foo", stackTrace: []},
+      userCustomData: {},
+      tags: ["development"],
+      request: {
+        hostName: "localhost",
+        url: "/make-me-an-error-charlie",
+        httpMethod: "GET",
+        iPAddress: "::1",
+        queryString: {
+          param1: "1",
+          param2: "2",
+          param3: "3",
+        },
+        headers: {
+          "Host"=>"localhost:3000",
+          "Connection"=>"keep-alive",
+          "Upgrade-Insecure_requests"=>"1",
+          "User-Agent"=> "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36",
+          "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+          "Accept-Encoding"=>"gzip, deflate, sdch, br",
+          "Accept-Language"=>"en-US,en;q=0.8",
+          "Version"=>"HTTP/1.1"
+        },
+        form: {
+          controller: "home",
+          action: "raise_error"
+        },
+        rawData: {
+          controller: "home",
+          action: "raise_error"
+        }
+      }
+    }
+    expected = {
+      machineName: "mindscapes-MacBook-Pro.local",
+      version: nil,
+      client: {name: "Raygun4Ruby Gem", version: "1.1.12", clientUrl: "https://github.com/MindscapeHQ/raygun4ruby"},
+      error: {className: "Exception", message: "foo", stackTrace: []},
+      userCustomData: {},
+      tags: ["development"],
+      request: {
+        hostName: "localhost",
+        url: "/make-me-an-error-charlie",
+        httpMethod: "GET",
+        iPAddress: "::1",
+        queryString: {
+          param1: "1",
+          param2: "2",
+        },
+        headers: {
+          "Host"=>"localhost:3000",
+          "Connection"=>"keep-alive",
+          "Upgrade-Insecure_requests"=>"1",
+          "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        },
+        form: {
+          controller: "home",
+        },
+        rawData: {
+          controller: "home",
+        }
+      }
+    }
+
+    new_payload = service.call(shape, payload)
+
+    new_payload.must_equal(expected)
+  end
+end

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -577,11 +577,11 @@ class ClientTest < Raygun::UnitTest
 
   def test_filter_payload_with_whitelist_request_post_except_formkey
     Raygun.configuration.filter_payload_with_whitelist = true
-    Raygun.configuration.whitelist_payload_shape = Raygun.configuration.whitelist_payload.shape.merge({
+    Raygun.configuration.whitelist_payload_shape[:request] = Raygun.configuration.whitelist_payload_shape[:request].merge(
       form: {
         username: true
       }
-    })
+    )
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -686,6 +686,50 @@ class ClientTest < Raygun::UnitTest
     assert_equal expected_hash, details[:request]
   end
 
+  def test_filter_payload_with_whitelist_being_false_does_not_filter_query_string
+    e = TestException.new("A test message")
+    e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
+                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+
+    sample_env_hash = {
+      "SERVER_NAME"=>"localhost",
+      "REQUEST_METHOD"=>"GET",
+      "REQUEST_PATH"=>"/",
+      "PATH_INFO"=>"/",
+      "QUERY_STRING"=>"a=b&c=4945438",
+      "REQUEST_URI"=>"/?a=b&c=4945438",
+      "HTTP_VERSION"=>"HTTP/1.1",
+      "HTTP_HOST"=>"localhost:3000",
+      "HTTP_CONNECTION"=>"keep-alive",
+      "HTTP_CACHE_CONTROL"=>"max-age=0",
+      "HTTP_ACCEPT"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "HTTP_USER_AGENT"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.22 Safari/537.36",
+      "HTTP_ACCEPT_ENCODING"=>"gzip,deflate,sdch",
+      "HTTP_ACCEPT_LANGUAGE"=>"en-US,en;q=0.8",
+      "HTTP_COOKIE"=>"cookieval",
+      "GATEWAY_INTERFACE"=>"CGI/1.2",
+      "SERVER_PORT"=>"3000",
+      "SERVER_PROTOCOL"=>"HTTP/1.1",
+      "SCRIPT_NAME"=>"",
+      "REMOTE_ADDR"=>"127.0.0.1"
+    }
+
+    expected_hash = {
+      hostName:    "localhost",
+      url:         "/",
+      httpMethod:  "GET",
+      iPAddress:   "127.0.0.1",
+      queryString: { "a" => "b", "c" => "4945438" },
+      headers:     { "Version"=>"HTTP/1.1", "Host"=>"localhost:3000", "Connection"=>"keep-alive", "Cache-Control"=>"max-age=0", "Accept"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", "User-Agent"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.22 Safari/537.36", "Accept-Encoding"=>"gzip,deflate,sdch", "Accept-Language"=>"en-US,en;q=0.8", "Cookie"=>"cookieval" },
+      form:        {},
+      rawData:     {}
+    }
+
+    details = @client.send(:build_payload_hash, e, sample_env_hash)[:details]
+
+    assert_equal expected_hash, details[:request]
+  end
+
   def test_filter_payload_with_whitelist_request_specific_keys
     Raygun.configuration.filter_payload_with_whitelist = true
     Raygun.configuration.whitelist_payload_keys = ['request', 'url', 'httpMethod', 'hostName']

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -431,6 +431,19 @@ class ClientTest < Raygun::UnitTest
     assert_equal '[FILTERED]', @client.send(:build_payload_hash, e)[:details][:error]
   end
 
+  def test_filter_whitelist_all_doesnt_filter_client
+    Raygun.configuration.filter_whitelists_all = true
+    Raygun.configuration.filter_parameters = ['client']
+
+    e = TestException.new("A test message")
+    e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
+                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+
+    client_details = @client.send(:client_details)
+
+    assert_equal client_details, @client.send(:build_payload_hash, e)[:details][:client]
+  end
+
   private
 
     def sample_env_hash

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -428,7 +428,7 @@ class ClientTest < Raygun::UnitTest
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
                        "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
-    assert_equal nil, @client.send(:build_payload_hash, e)[:details][:error]
+    assert_equal '[FILTERED]', @client.send(:build_payload_hash, e)[:details][:error]
   end
 
   private

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -420,6 +420,17 @@ class ClientTest < Raygun::UnitTest
     end
   end
 
+  def test_filter_whitelist_all
+    Raygun.configuration.filter_whitelists_all = true
+    Raygun.configuration.filter_parameters = ['error']
+
+    e = TestException.new("A test message")
+    e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
+                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+
+    assert_equal nil, @client.send(:build_payload_hash, e)[:details][:error]
+  end
+
   private
 
     def sample_env_hash

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -463,7 +463,7 @@ class ClientTest < Raygun::UnitTest
     end
   end
 
-  def test_filter_whitelists_all_exclude_error
+  def test_filter_whitelists_all_whitelist_error
     Raygun.configuration.filter_whitelists_all = true
     Raygun.configuration.filter_parameters = ['error', 'className', 'message', 'stackTrace']
 
@@ -485,7 +485,7 @@ class ClientTest < Raygun::UnitTest
     assert_equal expected_hash, details[:error]
   end
 
-  def test_filter_whitelists_all_exclude_error_except_stacktrace
+  def test_filter_whitelists_all_whitelist_error_except_stacktrace
     Raygun.configuration.filter_whitelists_all = true
     Raygun.configuration.filter_parameters = ['error', 'className', 'message']
 

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -420,8 +420,8 @@ class ClientTest < Raygun::UnitTest
     end
   end
 
-  def test_filter_whitelists_all_default
-    Raygun.configuration.filter_whitelists_all = true
+  def test_filter_payload_with_whitelist_default
+    Raygun.configuration.filter_payload_with_whitelist = true
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
@@ -436,8 +436,8 @@ class ClientTest < Raygun::UnitTest
     assert_equal '[FILTERED]', details[:request]
   end
 
-  def test_filter_whitelists_all_never_filters_client
-    Raygun.configuration.filter_whitelists_all = true
+  def test_filter_payload_with_whitelist_never_filters_client
+    Raygun.configuration.filter_payload_with_whitelist = true
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
@@ -448,9 +448,9 @@ class ClientTest < Raygun::UnitTest
     assert_equal client_details, @client.send(:build_payload_hash, e)[:details][:client]
   end
 
-  def test_filter_whitelists_all_never_filters_toplevel
+  def test_filter_payload_with_whitelist_never_filters_toplevel
     Timecop.freeze do
-      Raygun.configuration.filter_whitelists_all = true
+      Raygun.configuration.filter_payload_with_whitelist = true
 
       e = TestException.new("A test message")
       e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
@@ -463,8 +463,8 @@ class ClientTest < Raygun::UnitTest
     end
   end
 
-  def test_filter_whitelists_all_whitelist_error
-    Raygun.configuration.filter_whitelists_all = true
+  def test_filter_payload_with_whitelist_exclude_error
+    Raygun.configuration.filter_payload_with_whitelist = true
     Raygun.configuration.filter_parameters = ['error', 'className', 'message', 'stackTrace']
 
     e = TestException.new("A test message")
@@ -485,8 +485,8 @@ class ClientTest < Raygun::UnitTest
     assert_equal expected_hash, details[:error]
   end
 
-  def test_filter_whitelists_all_whitelist_error_except_stacktrace
-    Raygun.configuration.filter_whitelists_all = true
+  def test_filter_payload_with_whitelist_exclude_error_except_stacktrace
+    Raygun.configuration.filter_payload_with_whitelist = true
     Raygun.configuration.filter_parameters = ['error', 'className', 'message']
 
     e = TestException.new("A test message")

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -429,7 +429,7 @@ class ClientTest < Raygun::UnitTest
 
       e = TestException.new("A test message")
       e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                        "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
       client_details = @client.send(:client_details)
 
@@ -444,7 +444,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     client_details = @client.send(:client_details)
 
@@ -456,7 +456,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     details = @client.send(:build_payload_hash, e)[:details]
 
@@ -484,7 +484,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     details = @client.send(:build_payload_hash, e)[:details]
 
@@ -511,7 +511,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     details = @client.send(:build_payload_hash, e)[:details]
 
@@ -532,7 +532,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     details = @client.send(:build_payload_hash, e)[:details]
 
@@ -553,7 +553,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     post_body_env_hash = sample_env_hash.merge(
       "rack.input"=>StringIO.new("a=b&c=4945438&password=swordfish")
@@ -577,15 +577,17 @@ class ClientTest < Raygun::UnitTest
 
   def test_filter_payload_with_whitelist_request_post_except_formkey
     Raygun.configuration.filter_payload_with_whitelist = true
-    Raygun.configuration.whitelist_payload_shape[:request] = Raygun.configuration.whitelist_payload_shape[:request].merge(
+    shape = Raygun.configuration.whitelist_payload_shape.dup
+    shape[:request] = Raygun.configuration.whitelist_payload_shape[:request].merge(
       form: {
         username: true
       }
     )
+    Raygun.configuration.whitelist_payload_shape = shape
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     post_body_env_hash = sample_env_hash.merge(
       "rack.input"=>StringIO.new("username=foo&password=swordfish")
@@ -612,7 +614,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     sample_env_hash = {
       "SERVER_NAME"=>"localhost",
@@ -655,13 +657,15 @@ class ClientTest < Raygun::UnitTest
 
   def test_filter_payload_with_whitelist_default_request_get_except_querystring
     Raygun.configuration.filter_payload_with_whitelist = true
-    Raygun.configuration.whitelist_payload_shape[:request] = Raygun::Configuration::DEFAULT_WHITELIST_PAYLOAD_SHAPE_REQUEST.tap do |h|
+    shape = Raygun.configuration.whitelist_payload_shape.dup
+    shape[:request] = Raygun::Configuration::DEFAULT_WHITELIST_PAYLOAD_SHAPE_REQUEST.dup.tap do |h|
       h.delete(:queryString)
     end
+    Raygun.configuration.whitelist_payload_shape = shape
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     sample_env_hash = {
       "SERVER_NAME"=>"localhost",
@@ -706,7 +710,7 @@ class ClientTest < Raygun::UnitTest
     Raygun.configuration.filter_payload_with_whitelist = false
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     sample_env_hash = {
       "SERVER_NAME"=>"localhost",
@@ -759,7 +763,7 @@ class ClientTest < Raygun::UnitTest
 
     e = TestException.new("A test message")
     e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
-                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+                     "/another/path/foo.rb:1234:in `block (3 levels) run'"])
 
     details = @client.send(:build_payload_hash, e, sample_env_hash)[:details]
 
@@ -780,29 +784,29 @@ class ClientTest < Raygun::UnitTest
 
   private
 
-    def sample_env_hash
-      {
-        "SERVER_NAME"=>"localhost",
-        "REQUEST_METHOD"=>"POST",
-        "REQUEST_PATH"=>"/",
-        "PATH_INFO"=>"/",
-        "QUERY_STRING"=>"",
-        "REQUEST_URI"=>"/",
-        "HTTP_VERSION"=>"HTTP/1.1",
-        "HTTP_HOST"=>"localhost:3000",
-        "HTTP_CONNECTION"=>"keep-alive",
-        "HTTP_CACHE_CONTROL"=>"max-age=0",
-        "HTTP_ACCEPT"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "HTTP_USER_AGENT"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.22 Safari/537.36",
-        "HTTP_ACCEPT_ENCODING"=>"gzip,deflate,sdch",
-        "HTTP_ACCEPT_LANGUAGE"=>"en-US,en;q=0.8",
-        "HTTP_COOKIE"=>"cookieval",
-        "GATEWAY_INTERFACE"=>"CGI/1.2",
-        "SERVER_PORT"=>"3000",
-        "SERVER_PROTOCOL"=>"HTTP/1.1",
-        "SCRIPT_NAME"=>"",
-        "REMOTE_ADDR"=>"127.0.0.1"
-      }
-    end
+  def sample_env_hash
+    {
+      "SERVER_NAME"=>"localhost",
+      "REQUEST_METHOD"=>"POST",
+      "REQUEST_PATH"=>"/",
+      "PATH_INFO"=>"/",
+      "QUERY_STRING"=>"",
+      "REQUEST_URI"=>"/",
+      "HTTP_VERSION"=>"HTTP/1.1",
+      "HTTP_HOST"=>"localhost:3000",
+      "HTTP_CONNECTION"=>"keep-alive",
+      "HTTP_CACHE_CONTROL"=>"max-age=0",
+      "HTTP_ACCEPT"=>"text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "HTTP_USER_AGENT"=>"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.22 Safari/537.36",
+      "HTTP_ACCEPT_ENCODING"=>"gzip,deflate,sdch",
+      "HTTP_ACCEPT_LANGUAGE"=>"en-US,en;q=0.8",
+      "HTTP_COOKIE"=>"cookieval",
+      "GATEWAY_INTERFACE"=>"CGI/1.2",
+      "SERVER_PORT"=>"3000",
+      "SERVER_PROTOCOL"=>"HTTP/1.1",
+      "SCRIPT_NAME"=>"",
+      "REMOTE_ADDR"=>"127.0.0.1"
+    }
+  end
 
 end

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -510,6 +510,31 @@ class ClientTest < Raygun::UnitTest
     assert_equal whitelisted_hash, details[:error]
   end
 
+  def test_filter_payload_with_whitelist_proc
+    Raygun.configuration.filter_payload_with_whitelist = true
+
+    Raygun.configuration.whitelist_payload_keys do |payload|
+      payload
+    end
+
+    e = TestException.new("A test message")
+    e.set_backtrace(["/some/folder/some_file.rb:123:in `some_method_name'",
+                       "/another/path/foo.rb:1234:in `block (3 levels) run'"])
+
+    whitelisted_hash =
+    {
+      :className=>"ClientTest::TestException",
+      :message=>"A test message", 
+      :stackTrace=> [
+        { lineNumber: "123",  fileName: "/some/folder/some_file.rb", methodName: "some_method_name" },
+        { lineNumber: "1234", fileName: "/another/path/foo.rb",      methodName: "block (3 levels) run" }
+      ]
+    }
+
+    details = @client.send(:build_payload_hash, e)[:details]
+    assert_equal whitelisted_hash, details[:error]
+  end
+
   def test_filter_payload_with_whitelist_default_request_post
     Raygun.configuration.filter_payload_with_whitelist = true
 

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -80,4 +80,16 @@ class ConfigurationTest < Raygun::UnitTest
     assert_equal(false, Raygun.configuration.filter_payload_with_whitelist)
   end
 
+  def test_setting_whitelist_payload_keys_to_proc
+    Raygun.setup do |config|
+      config.whitelist_payload_keys do |hash|
+        # No-op
+      end
+    end
+
+    assert Raygun.configuration.whitelist_payload_keys.is_a?(Proc)
+    ensure
+      Raygun.configuration.whitelist_payload_keys = nil
+  end
+
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -82,14 +82,14 @@ class ConfigurationTest < Raygun::UnitTest
 
   def test_setting_whitelist_payload_keys_to_proc
     Raygun.setup do |config|
-      config.whitelist_payload_keys do |hash|
+      config.whitelist_payload_shape do |hash|
         # No-op
       end
     end
 
-    assert Raygun.configuration.whitelist_payload_keys.is_a?(Proc)
+    assert Raygun.configuration.whitelist_payload_shape.is_a?(Proc)
     ensure
-      Raygun.configuration.whitelist_payload_keys = nil
+      Raygun.configuration.whitelist_payload_shape = nil
   end
 
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -76,4 +76,8 @@ class ConfigurationTest < Raygun::UnitTest
     Raygun.configuration.filter_parameters = nil
   end
 
+  def test_filter_whitelists_all_default
+    assert_equal(false, Raygun.configuration.filter_whitelists_all)
+  end
+
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -76,8 +76,8 @@ class ConfigurationTest < Raygun::UnitTest
     Raygun.configuration.filter_parameters = nil
   end
 
-  def test_filter_whitelists_all_default
-    assert_equal(false, Raygun.configuration.filter_whitelists_all)
+  def test_filter_payload_with_whitelist_default
+    assert_equal(false, Raygun.configuration.filter_payload_with_whitelist)
   end
 
 end


### PR DESCRIPTION
By request, a new config option `filter_payload_with_whitelist` (set to false by default) which reuses `filter_parameters`, but changes it to sanitize all values if they are not present in that array. This is applied recursively and for all nodes in the payload, e.g both branch and leaf nodes, barring the required occurredOn, details and client hashes.

Also includes a fix when running tests locally without a Rails gem installed (rails_env gets a `nil` tag appended).