### PR TITLE
Introduce exception raygun_custom_data instance method

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -10,6 +10,7 @@ require "raygun/configuration"
 require "raygun/client"
 require "raygun/middleware/rack_exception_interceptor"
 require "raygun/testable"
+require "raygun/error"
 require "raygun/railtie" if defined?(Rails)
 
 module Raygun

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -143,6 +143,8 @@ module Raygun
       # see http://raygun.io/raygun-providers/rest-json-api?v=1
       def build_payload_hash(exception_instance, env = {})
         custom_data = filter_custom_data(env) || {}
+        exception_custom_data = exception_instance.respond_to?(:raygun_custom_data) ? exception_instance.raygun_custom_data : {}
+
         tags = env.delete(:tags) || []
 
         tags << rails_env || rack_env
@@ -154,7 +156,7 @@ module Raygun
             version:        version,
             client:         client_details,
             error:          error_details(exception_instance),
-            userCustomData: Raygun.configuration.custom_data.merge(custom_data),
+            userCustomData: Raygun.configuration.custom_data.merge(custom_data).merge(exception_custom_data),
             tags:           Raygun.configuration.tags.concat(tags).compact.uniq,
             request:        request_information(env)
         }

--- a/lib/raygun/error.rb
+++ b/lib/raygun/error.rb
@@ -1,0 +1,10 @@
+module Raygun
+  class Error < StandardError
+    attr_reader :raygun_custom_data
+
+    def initialize(message, raygun_custom_data = {})
+      super(message)
+      @raygun_custom_data = raygun_custom_data
+    end
+  end
+end

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -248,6 +248,15 @@ class ClientTest < Raygun::UnitTest
     assert_equal expected_form_hash, @client.send(:request_information, put_body_env_hash)[:rawData]
   end
 
+  def test_error_raygun_custom_data
+    custom_data = { "kappa" => "keepo" }
+    e           = Raygun::Error.new("A test message", custom_data)
+    test_env    = {}
+    expected_form_hash = test_env.merge(custom_data)
+
+    assert_equal expected_form_hash, @client.send(:build_payload_hash, e, test_env)[:details][:userCustomData]
+  end
+
   def test_filtering_parameters
     post_body_env_hash = sample_env_hash.merge(
       "rack.input"=>StringIO.new("a=b&c=4945438&password=swordfish")


### PR DESCRIPTION
To support the case:

I want to raise an exception and have my Rack middleware(s) handle it. However, I also want to include custom data to raygun.

AFAICT this case was not supported, so here we are. Open to feedback. Thanks!