### PR TITLE
Notify raygun when raygun4ruby raises an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Features:
   - Added two new configuration options, `filter_payload_with_whitelist` and `whitelist_payload_shape`
     - See [README.md](https://github.com/MindscapeHQ/raygun4ruby#filtering-the-payload-by-whitelist) for an example of how to use them
+  - When raygun4ruby encounters an exception trying to track an exception it will try once to send that exception to Raygun so you are notified
 
 Bugfixes:
   - raygun4ruby will no longer crash and suppress app exceptions when the API key is not configured


### PR DESCRIPTION
Try a single time to send an exception generated when track_exception is
called to raygun with the original exceptions backtrace attached as
custom data

Resolves #99

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/104)
<!-- Reviewable:end -->
