### PR TITLE
Correctly record raw request data for Rack based apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0 (20/04/2017)
+
+Bugfixes:
+  - Fix broken handling of raw request body reading in Rack applications ([#116](https://github.com/MindscapeHQ/raygun4ruby/pull/116))
+    - This is a breaking change to how raw data was being read before so it requires a major version bump
+    - Raw request data reading is now disabled by default and can be enabled via the `record_raw_data` configuration option
 ## 1.5.0 (16/03/2017)
 
 Features

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -55,6 +55,8 @@ module Raygun
         Client.new.track_exception(exception_instance, env, user)
       end
     rescue Exception => e
+      p "Exception"
+      p e.inspect
       if configuration.failsafe_logger
         failsafe_log("Problem reporting exception to Raygun: #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}")
       end

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -55,8 +55,6 @@ module Raygun
         Client.new.track_exception(exception_instance, env, user)
       end
     rescue Exception => e
-      p "Exception"
-      p e.inspect
       if configuration.failsafe_logger
         failsafe_log("Problem reporting exception to Raygun: #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}")
       end

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -132,6 +132,8 @@ module Raygun
       end
 
       def raw_data(rack_env)
+        return unless Raygun.configuration.record_raw_data
+
         request = Rack::Request.new(rack_env)
 
         if rack_env['rack.input'] && !request.form_data?

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -133,8 +133,11 @@ module Raygun
 
       def raw_data(rack_env)
         request = Rack::Request.new(rack_env)
-        unless request.form_data?
-          form_params(rack_env)
+
+        if rack_env['rack.input'] && !request.form_data?
+          rack_env['rack.input'].read
+        else
+          {}
         end
       end
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -135,9 +135,16 @@ module Raygun
         return unless Raygun.configuration.record_raw_data
 
         request = Rack::Request.new(rack_env)
+        input = rack_env['rack.input']
 
-        if rack_env['rack.input'] && !request.form_data?
-          rack_env['rack.input'].read
+        if input && !request.form_data?
+          current_position = input.pos
+          input.rewind
+
+          body = (input.read || '').slice(0, 4096)
+          input.seek(current_position)
+
+          body
         else
           {}
         end

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -70,6 +70,10 @@ module Raygun
     # Override this if you wish to connect to a different Raygun API than the standard one
     config_option :api_url
 
+    # Should Raygun include the raw request body in the payload? This will not include
+    # form submissions and will not be filtered by the blacklist
+    config_option :record_raw_data
+
     # Exception classes to ignore by default
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
@@ -119,7 +123,8 @@ module Raygun
         whitelist_payload_shape:          DEFAULT_WHITELIST_PAYLOAD_SHAPE,
         proxy_settings:                   {},
         debug:                            false,
-        api_url:                          'https://api.raygun.io/'
+        api_url:                          'https://api.raygun.io/',
+        record_raw_data:                  false
       })
     end
 

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "1.5.0"
+  VERSION = "2.0.0"
 end

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -233,6 +233,17 @@ class ClientTest < Raygun::UnitTest
     assert_equal '{"foo": "bar"}', @client.send(:request_information, env_hash)[:rawData]
   end
 
+  def test_raw_post_body_with_more_than_4096_chars
+    input = "0" * 5000;
+    env_hash = sample_env_hash.merge({
+      "CONTENT_TYPE" => "application/json",
+      "REQUEST_METHOD" => "POST",
+      "rack.input" => StringIO.new(input)
+    })
+
+    assert_equal input.slice(0, 4096), @client.send(:request_information, env_hash)[:rawData]
+  end
+
   def test_raw_post_body_with_config_disabled
     Raygun.configuration.record_raw_data = false
     env_hash = sample_env_hash.merge({

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -29,6 +29,7 @@ class ClientTest < Raygun::UnitTest
   def setup
     super
     @client = Raygun::Client.new
+    Raygun.configuration.record_raw_data = true
     fake_successful_entry
 
     # Force NZ time zone for utcOffset tests
@@ -230,6 +231,17 @@ class ClientTest < Raygun::UnitTest
     })
 
     assert_equal '{"foo": "bar"}', @client.send(:request_information, env_hash)[:rawData]
+  end
+
+  def test_raw_post_body_with_config_disabled
+    Raygun.configuration.record_raw_data = false
+    env_hash = sample_env_hash.merge({
+      "CONTENT_TYPE" => "application/json",
+      "REQUEST_METHOD" => "POST",
+      "rack.input" => StringIO.new('{"foo": "bar"}')
+    })
+
+    assert_equal(nil, @client.send(:request_information, env_hash)[:rawData])
   end
 
   def test_error_raygun_custom_data

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -129,4 +129,8 @@ class ConfigurationTest < Raygun::UnitTest
   def test_api_url_default
     assert_equal "https://api.raygun.io/", Raygun.configuration.api_url
   end
+
+  def test_record_raw_data_default
+    assert_equal false, Raygun.configuration.record_raw_data
+  end
 end


### PR DESCRIPTION
The body of a POST request was not being correctly recorded by the raw_data method before. This makes it so Raygun will correctly read the body of POST requests out of the request when an exception occurs and send it along with the payload. Because this does not go through the blacklisting process (due to the fact it's arbitrary string data) form submissions are not included in this. The request gets truncated to 4096 characters.

Because sensitive data may be in the request body this is opt in behind a configuration flag.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/116)
<!-- Reviewable:end -->
