### PR TITLE
Background sending of exceptions so web request thread is not blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0
+
+Features
+  - Opt in support for sending exceptions in a background thread to not block web request thread during IO ([#117](https://github.com/MindscapeHQ/raygun4ruby/pull/117))
+
+Bugfixes
+ - Don't attempt to read raw data during GET requests or if rack.input buffer is empty
+
 ## 2.1.0
 
 Features

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can then test your Raygun integration by running:
 
 You should see an "ItWorksException" appear in your Raygun dashboard. You're ready to zap those errors!
 
-NB: Raygun4Ruby currently requires Ruby >= 1.9
+NB: Raygun4Ruby currently requires Ruby >= 2.0
 
 Note that the generator will create a file in `config/initializers` called "raygun.rb". If you need to do any further configuration or customization of Raygun, that's the place to do it!
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -136,8 +136,11 @@ module Raygun
 
         request = Rack::Request.new(rack_env)
         input = rack_env['rack.input']
+        return if request.get?
 
-        if input && !request.form_data?
+        # If size is 0 the buffer is at best empty and at worst
+        # something like the Puma::NullIO buffer which is missing methods
+        if input && input.size && !request.form_data?
           current_position = input.pos
           input.rewind
 

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -74,6 +74,9 @@ module Raygun
     # form submissions and will not be filtered by the blacklist
     config_option :record_raw_data
 
+    # Should the exceptions to Raygun be sent asynchronously?
+    config_option :send_in_background
+
     # Exception classes to ignore by default
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
@@ -111,7 +114,7 @@ module Raygun
       @config_values = {}
 
       # set default attribute values
-      @defaults = OpenStruct.new({
+      @defaults = OpenStruct.new(
         ignore:                        IGNORE_DEFAULT,
         custom_data:                   {},
         tags:                          [],
@@ -125,8 +128,9 @@ module Raygun
         debug:                         false,
         api_url:                       'https://api.raygun.io/',
         breadcrumb_level:              :info,
-        record_raw_data:               false
-      })
+        record_raw_data:               false,
+        send_in_background:            false
+      )
     end
 
     def [](key)

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "httparty", "> 0.13.7"
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "rack"
+  spec.add_runtime_dependency "concurrent-ruby"
 
   spec.add_development_dependency "bundler", ">= 1.1"
   spec.add_development_dependency "rake", "0.9.6"

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -213,7 +213,7 @@ class ClientTest < Raygun::UnitTest
       queryString: { "a" => "b", "c" => "4945438" },
       headers:     { "Version"=>"HTTP/1.1", "Host"=>"localhost:3000", "Cookie"=>"cookieval" },
       form:        {},
-      rawData:     {}
+      rawData:     nil
     }
 
     assert_equal expected_hash, @client.send(:request_information, env_hash)
@@ -550,7 +550,7 @@ class ClientTest < Raygun::UnitTest
       queryString: { "a" => "b", "c" => "4945438" },
       headers:     { "Version"=>"HTTP/1.1", "Host"=>"localhost:3000", "Cookie"=>"cookieval" },
       form:        {},
-      rawData:     {}
+      rawData:     nil
     }
 
     details = @client.send(:build_payload_hash, test_exception, env_hash)[:details]
@@ -574,7 +574,7 @@ class ClientTest < Raygun::UnitTest
       queryString: "[FILTERED]",
       headers:     { "Version"=>"HTTP/1.1", "Host"=>"localhost:3000", "Cookie"=>"cookieval" },
       form:        {},
-      rawData:     {}
+      rawData:     nil
     }
 
     details = @client.send(:build_payload_hash, test_exception, sample_env_hash)[:details]
@@ -597,7 +597,7 @@ class ClientTest < Raygun::UnitTest
       queryString: { "a" => "b", "c" => "4945438" },
       headers:     { "Version"=>"HTTP/1.1", "Host"=>"localhost:3000", "Cookie"=>"cookieval" },
       form:        {},
-      rawData:     {}
+      rawData:     nil
     }
 
     details = @client.send(:build_payload_hash, test_exception, env_hash)[:details]

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -159,4 +159,8 @@ class ConfigurationTest < Raygun::UnitTest
   def test_record_raw_data_default
     assert_equal false, Raygun.configuration.record_raw_data
   end
+
+  def test_send_in_background_default
+    assert_equal false, Raygun.configuration.send_in_background
+  end
 end


### PR DESCRIPTION
Send exceptions in background thread via concurrent-ruby

Disabled by default, can be enabled with config flag `send_in_background` set to true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/117)
<!-- Reviewable:end -->
