### PR TITLE
Backward compatible affected_user_identifier_methods

### DIFF
--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -163,7 +163,7 @@ module Raygun
 
     def affected_user_identifier_methods
       Raygun.deprecation_warning("Please note: You should now user config.affected_user_method_mapping.Identifier instead of config.affected_user_identifier_methods")
-      read_value(:affected_user_mapping).Identifier
+      read_value(:affected_user_mapping)[:identifier]
     end
 
     private

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -163,7 +163,7 @@ module Raygun
 
     def affected_user_identifier_methods
       Raygun.deprecation_warning("Please note: You should now user config.affected_user_method_mapping.Identifier instead of config.affected_user_identifier_methods")
-      read_value(:affected_user_method_mapping).Identifier
+      read_value(:affected_user_mapping).Identifier
     end
 
     private


### PR DESCRIPTION
fix: raygun ruby undefined method `Identifier` for nil:NilClass