### PR TITLE
Make raw_data handling more robust and fix in unicorn

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -132,20 +132,18 @@ module Raygun
       end
 
       def raw_data(rack_env)
-        return unless Raygun.configuration.record_raw_data
-
         request = Rack::Request.new(rack_env)
-        input = rack_env['rack.input']
+
+        return unless Raygun.configuration.record_raw_data
         return if request.get?
 
-        # If size is 0 the buffer is at best empty and at worst
-        # something like the Puma::NullIO buffer which is missing methods
-        if input && input.size && input.respond_to?(:pos) && !request.form_data?
-          current_position = input.pos
+        input = rack_env['rack.input']
+
+        if input && !request.form_data?
           input.rewind
 
-          body = (input.read || '').slice(0, 4096)
-          input.seek(current_position)
+          body = input.read(4096) || ''
+          input.rewind
 
           body
         else

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -656,21 +656,6 @@ class ClientTest < Raygun::UnitTest
     assert breadcrumbs[0].is_a? Hash
   end
 
-  def test_raw_data_rewinds_and_restores_correctly
-    buffer = StringIO.new('123456789')
-    rack_env = {
-      REQUEST_METHOD: 'POST',
-      'rack.input' => buffer
-    }
-
-    buffer.seek(2)
-
-    raw_data = @client.send(:raw_data, rack_env)
-
-    assert_equal '123456789', raw_data
-    assert_equal buffer.pos, 2
-  end
-
   def test_raw_data_does_not_crash_on_buffer_without_pos
     buffer = StringIO.new('123456789')
     rack_env = {
@@ -682,7 +667,7 @@ class ClientTest < Raygun::UnitTest
 
     raw_data = @client.send(:raw_data, rack_env)
 
-    assert_equal({}, raw_data)
+    assert_equal('123456789', raw_data)
   end
 
   private


### PR DESCRIPTION
This changes the raw_data method to only use methods allowed on the
input buffer by the rack specification. This fixes raw_data for unicorn.

Raw data handling tested in Phusion Passenger (v5), Unicorn (v5) and
Puma (v3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/125)
<!-- Reviewable:end -->
