### PR TITLE
Timeout network request to send crash reports to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.7.0 (19/02/2018)
+
+Features
+ - Add configuration option to control network timeouts when sending error reports, default value is 10 seconds ([#129](https://github.com/MindscapeHQ/raygun4ruby/pull/129))
+
 ## 2.6.0 (25/10/2017)
 
 Features

--- a/Rakefile
+++ b/Rakefile
@@ -8,13 +8,11 @@ namespace :test do
   desc "Test the basics of the adapter"
   Rake::TestTask.new(:units) do |t|
     t.test_files = FileList["test/unit/*_test.rb", "specs/**/*_spec.rb"]
-    t.verbose = true
   end
 
   desc "Run a test against the live API"
   Rake::TestTask.new(:integration) do |t|
     t.test_files = FileList["test/integration/*_test.rb"]
-    t.verbose = true
   end
 
 end

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -118,7 +118,7 @@ module Raygun
     def track_exception_async(*args)
       future = Concurrent::Future.execute { track_exception_sync(*args) }
       future.add_observer(lambda do |_, value, reason|
-        if value == nil || value.response.code != "202"
+        if value == nil || !value.responds_to?(:response) || value.response.code != "202"
           log("unexpected response from Raygun, could indicate error: #{value.inspect}")
         end
       end, :call)

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -51,6 +51,10 @@ module Raygun
       configuration.defaults
     end
 
+    def reset_configuration
+      @configuration = Configuration.new
+    end
+
     def configured?
       !!configuration.api_key
     end

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -131,8 +131,10 @@ module Raygun
     def track_exception_sync(exception_instance, env, user, retry_count)
       if should_report?(exception_instance)
         log('attempting to send exception')
-        Client.new.track_exception(exception_instance, env, user)
+        resp = Client.new.track_exception(exception_instance, env, user)
         log('sent payload to api')
+
+        resp
       end
     rescue Exception => e
       log('error sending exception to raygun, see failsafe logger for more information')

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -132,6 +132,7 @@ module Raygun
       if should_report?(exception_instance)
         log('attempting to send exception')
         Client.new.track_exception(exception_instance, env, user)
+        log('sent payload to api')
       end
     rescue Exception => e
       log('error sending exception to raygun, see failsafe logger for more information')

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -16,6 +16,7 @@ module Raygun
 
       enable_http_proxy if Raygun.configuration.proxy_settings[:address]
       self.class.base_uri Raygun.configuration.api_url
+      self.class.default_timeout(Raygun.configuration.error_report_send_timeout)
     end
 
     def require_api_key
@@ -242,7 +243,13 @@ module Raygun
       def create_entry(payload_hash)
         Raygun.log('sending payload to api')
 
-        self.class.post("/entries", verify_peer: true, verify: true, headers: @headers, body: JSON.generate(payload_hash))
+        self.class.post(
+          "/entries",
+          verify_peer: true,
+          verify: true,
+          headers: @headers,
+          body: JSON.generate(payload_hash),
+        )
       end
 
       def filter_params_with_blacklist(params_hash = {}, extra_filter_keys = nil)

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -77,6 +77,9 @@ module Raygun
     # Should the exceptions to Raygun be sent asynchronously?
     config_option :send_in_background
 
+    # How long to wait for the POST request to the API server before timing out
+    config_option :error_report_send_timeout
+
     # Exception classes to ignore by default
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
@@ -129,7 +132,8 @@ module Raygun
         api_url:                       'https://api.raygun.io/',
         breadcrumb_level:              :info,
         record_raw_data:               false,
-        send_in_background:            false
+        send_in_background:            false,
+        error_report_send_timeout:     3000
       )
     end
 

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -133,7 +133,7 @@ module Raygun
         breadcrumb_level:              :info,
         record_raw_data:               false,
         send_in_background:            false,
-        error_report_send_timeout:     3000
+        error_report_send_timeout:     10
       )
     end
 

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "2.6.0"
+  VERSION = "2.7.0"
 end

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "concurrent-ruby"
 
   spec.add_development_dependency "bundler", ">= 1.1"
-  spec.add_development_dependency "rake", "0.9.6"
+  spec.add_development_dependency "rake", "~> 11"
   spec.add_development_dependency "fakeweb", ["~> 1.3"]
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "minitest", "~> 4.2"
@@ -34,4 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sidekiq", [">= 3", "< 3.2.2"]
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "webmock"
 end

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.1"
   spec.add_development_dependency "rake", "~> 11"
-  spec.add_development_dependency "fakeweb", ["~> 1.3"]
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "minitest", "~> 4.2"
   spec.add_development_dependency "redis-namespace", ">= 1.3.1"

--- a/specs/raygun/raygun_spec.rb
+++ b/specs/raygun/raygun_spec.rb
@@ -1,0 +1,34 @@
+require_relative '../spec_helper'
+require 'stringio'
+
+describe Raygun do
+  let(:failsafe_logger) { FakeLogger.new }
+
+  describe '#track_exception' do
+    context 'send in background' do
+      before do
+        Raygun.setup do |c|
+          c.send_in_background = true
+          c.api_url = 'http://example.api'
+          c.api_key = 'foo'
+          c.debug = true
+          c.failsafe_logger = failsafe_logger
+        end
+      end
+
+      context 'request times out' do
+        before do
+          stub_request(:post, 'http://example.api/entries').to_timeout
+        end
+
+        it 'logs the failure to the failsafe logger' do
+          error = StandardError.new
+
+          Raygun.track_exception(error)
+
+          failsafe_logger.get.must_match /Problem reporting exception to Raygun/
+        end
+      end
+    end
+  end
+end

--- a/specs/raygun/raygun_spec.rb
+++ b/specs/raygun/raygun_spec.rb
@@ -31,4 +31,18 @@ describe Raygun do
       end
     end
   end
+
+  describe '#reset_configuration' do
+    it 'clears any customized configuration options' do
+      Raygun.setup do |c|
+        c.api_url = 'http://test.api'
+      end
+
+      Raygun.configuration.api_url.must_equal 'http://test.api'
+
+      Raygun.reset_configuration
+
+      Raygun.configuration.api_url.must_equal Raygun.default_configuration.api_url
+    end
+  end
 end

--- a/specs/raygun/raygun_spec.rb
+++ b/specs/raygun/raygun_spec.rb
@@ -26,6 +26,8 @@ describe Raygun do
 
           Raygun.track_exception(error)
 
+          # Occasionally doesn't write to the failsafe logger, add small timeout to add some safety
+          sleep 0.1
           failsafe_logger.get.must_match /Problem reporting exception to Raygun/
         end
       end

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -6,5 +6,25 @@ require "fakeweb"
 require "timecop"
 require "mocha/mini_test"
 require "webmock/minitest"
+require 'stringio'
 
 alias :context :describe
+
+class FakeLogger
+  def initialize
+    @logger = StringIO.new
+  end
+
+  def info(message)
+    @logger.write(message)
+  end
+
+  def reset
+    @logger.string = ""
+  end
+
+  def get
+    @logger.string
+  end
+end
+

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -5,5 +5,6 @@ require "minitest/pride"
 require "fakeweb"
 require "timecop"
 require "mocha/mini_test"
+require "webmock/minitest"
 
 alias :context :describe

--- a/specs/spec_helper.rb
+++ b/specs/spec_helper.rb
@@ -2,7 +2,6 @@ ENV['RACK_ENV'] = 'test'
 require_relative "../lib/raygun.rb"
 require "minitest/autorun"
 require "minitest/pride"
-require "fakeweb"
 require "timecop"
 require "mocha/mini_test"
 require "webmock/minitest"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,6 @@ ENV['RACK_ENV'] = 'test'
 require_relative "../lib/raygun.rb"
 require "minitest/autorun"
 require "minitest/pride"
-require "fakeweb"
 require "timecop"
 require "mocha/mini_test"
 require 'stringio'
@@ -47,18 +46,15 @@ end
 class Raygun::UnitTest < MiniTest::Unit::TestCase
 
   def setup
-    FakeWeb.allow_net_connect = false
     Raygun.configuration.api_key = "test api key"
   end
 
-  def fake_successful_entry
-    FakeWeb.register_uri(:post, "https://api.raygun.io/entries", body: "", status: 202)
+  def teardown
+    reset_configuration
   end
 
-  def teardown
-    FakeWeb.clean_registry
-    FakeWeb.allow_net_connect = true
-    reset_configuration
+  def fake_successful_entry
+    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
   end
 
   def reset_configuration

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -34,8 +34,6 @@ class ClientTest < Raygun::UnitTest
 
     # Force NZ time zone for utcOffset tests
     ENV['TZ'] = 'UTC-13'
-
-    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
   end
 
   def test_record_breadcrumb_does_not_crash_without_initialized_store

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -34,6 +34,8 @@ class ClientTest < Raygun::UnitTest
 
     # Force NZ time zone for utcOffset tests
     ENV['TZ'] = 'UTC-13'
+
+    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
   end
 
   def test_record_breadcrumb_does_not_crash_without_initialized_store

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -179,4 +179,8 @@ class ConfigurationTest < Raygun::UnitTest
   def test_send_in_background_default
     assert_equal false, Raygun.configuration.send_in_background
   end
+
+  def test_error_report_send_timeout_default
+    assert_equal 3000, Raygun.configuration.error_report_send_timeout
+  end
 end

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -185,7 +185,7 @@ class ConfigurationTest < Raygun::UnitTest
   end
 
   def test_error_report_send_timeout_default
-    assert_equal 3000, Raygun.configuration.error_report_send_timeout
+    assert_equal 10, Raygun.configuration.error_report_send_timeout
   end
 
   def test_enable_reporting_default

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -12,6 +12,10 @@ class ConfigurationTest < Raygun::UnitTest
     end
   end
 
+  def teardown
+    Raygun.reset_configuration
+  end
+
   def test_setting_api_key_and_version
     assert_equal 9.9,              Raygun.configuration.version
     assert_equal "a test api key", Raygun.configuration.api_key
@@ -182,5 +186,9 @@ class ConfigurationTest < Raygun::UnitTest
 
   def test_error_report_send_timeout_default
     assert_equal 3000, Raygun.configuration.error_report_send_timeout
+  end
+
+  def test_enable_reporting_default
+    assert_equal true, Raygun.configuration.enable_reporting
   end
 end

--- a/test/unit/resque_failure_test.rb
+++ b/test/unit/resque_failure_test.rb
@@ -7,6 +7,8 @@ class ResqueFailureTest < Raygun::UnitTest
 
   def setup
     super
+
+    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
     fake_successful_entry
   end
 

--- a/test/unit/sidekiq_failure_test.rb
+++ b/test/unit/sidekiq_failure_test.rb
@@ -13,6 +13,8 @@ class SidekiqFailureTest < Raygun::UnitTest
 
   def setup
     super
+
+    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
     fake_successful_entry
   end
 


### PR DESCRIPTION
Adds configuration option for setting the timeout of the POST call to the API server when submitting a crash report.

This is primarily to ensure that when using the send_in_background configuration option that network issues don't cause a bunch of observables to stick around waiting for the network call to finish clogging up memory and threads.

Also bumps rake from v0.9.6 to v11 and replaces Fakeweb with webmock

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/129)
<!-- Reviewable:end -->
