### PR TITLE
Rescue StandardError, not Exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,14 @@ end
 
 begin
   # your lovely code here
-rescue Exception => e
+rescue => e
   Raygun.track_exception(e)
 end
 
 # You may also pass a user object as the third argument to allow affected user tracking, like so
 begin
   # your lovely code here
-rescue Exception => e
+rescue => e
   # The second argument is the request environment variables
   Raygun.track_exception(e, {}, user)
 end


### PR DESCRIPTION
It's not really idiomatic in Ruby to rescue Exception, and often not what 
the author intends, so it seemed good to not encourage it in the docs

More here: https://robots.thoughtbot.com/rescue-standarderror-not-exception