### PR TITLE
Apply #whitelist_payload_shape and #filter_parameters at the same time

### DIFF
--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -253,8 +253,6 @@ module Raygun
       end
 
       def filter_params_with_blacklist(params_hash = {}, extra_filter_keys = nil)
-        return params_hash if Raygun.configuration.filter_payload_with_whitelist
-
         filter_parameters = Raygun.configuration.filter_parameters
 
         if filter_parameters.is_a? Proc


### PR DESCRIPTION
We have a use case where we'd like to apply both `whitelist_payload_shape` and the `filter_parameters` at the same time: we use `whitelist_payload_shape` to filter out the `Authorization` header from requests, while we use `filter_parameters` for regular form & query fields. 

We could look into extending our `whitelist_payload_shape` to also filter out form & query fields but it looks pretty ugly. I was wondering why the two configurations are mutually exclusive and I couldn't see a reason why, hence my PR.

What do you think?