### PR TITLE
Fixes #139

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.1 (16/01/2019):
+Bugfix:
+  - Don't attempt to modify response unless JS api key is present
+  - Don't attempt to modify response unless it responds to indexing ([])
+  - See PR ([#140](https://github.com/MindscapeHQ/raygun4ruby/pull/140))
+
 ## 3.1.0 (15/01/2019):
 
   Feature:

--- a/lib/raygun/middleware/javascript_exception_tracking.rb
+++ b/lib/raygun/middleware/javascript_exception_tracking.rb
@@ -16,8 +16,10 @@ module Raygun::Middleware
     end
 
     def inject_javascript_to_response(response)
-      response[0].gsub!('</head>', "#{js_tracker.head_html}</head>")
-      response[0].gsub!('</body>', "#{js_tracker.body_html}</body>")
+      if Raygun.configuration.js_api_key.present? && response.respond_to?('[]')
+        response[0].gsub!('</head>', "#{js_tracker.head_html}</head>")
+        response[0].gsub!('</body>', "#{js_tracker.body_html}</body>")
+      end
 
       response
     end

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "3.1.0"
+  VERSION = "3.1.1"
 end


### PR DESCRIPTION
This fixes #139 by not touching the response object if no JS api key is present and not attempting to modify the response if it does not respond to `[]`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/140)
<!-- Reviewable:end -->
