### PR TITLE
Safe calling content-type header for Javascript exception tracking

### DIFF
--- a/lib/raygun/middleware/javascript_exception_tracking.rb
+++ b/lib/raygun/middleware/javascript_exception_tracking.rb
@@ -8,7 +8,7 @@ module Raygun::Middleware
       status, headers, response = @app.call(env)
 
       # It's a html file, inject our JS
-      if headers['Content-Type'].include?('text/html')
+      if headers['Content-Type']&.include?('text/html')
         response = inject_javascript_to_response(response)
       end
 


### PR DESCRIPTION
- Getting error  ```*** NoMethodError Exception: undefined method `include?' for nil:NilClass```
for this block in `JavascriptExceptionTracking` class

```ruby
      if headers['Content-Type'].include?('text/html')
        response = inject_javascript_to_response(response)
      end
```
- somehow the `headers['Content-Type']` is nil when there's 404 exception and getting 500 error instead of 404

- Using `Rails 5.1.6` and `jbuilder` gem with json format response 
