### PR TITLE
Reduce chance of failsafe report failure

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -146,15 +146,19 @@ module Raygun
       end
 
       if retry_count > 0
-        new_exception = e.exception("raygun4ruby encountered an exception processing your exception")
-        new_exception.set_backtrace(e.backtrace)
 
         env[:custom_data] ||= {}
         env[:custom_data].merge!(original_stacktrace: exception_instance.backtrace)
 
-        ::Raygun::Breadcrumbs::Store.clear
+        ::Raygun::Breadcrumbs::Store.replace([])
 
-        track_exception(new_exception, env, user, retry_count - 1)
+        ::Raygun.record_breadcrumb(
+          :message => "Payload modified:\n\n We have stripped the breadcrumb information as this payload exceeded maximum payload size of 128KB. \n",
+          :category => "Notification",
+          :level => :info,
+        )
+
+        track_exception(exception_instance, env, user, retry_count - 1)
       else
         raise e
       end

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -152,6 +152,8 @@ module Raygun
         env[:custom_data] ||= {}
         env[:custom_data].merge!(original_stacktrace: exception_instance.backtrace)
 
+        ::Raygun::Breadcrumbs::Store.clear
+
         track_exception(new_exception, env, user, retry_count - 1)
       else
         raise e

--- a/lib/raygun/breadcrumbs/store.rb
+++ b/lib/raygun/breadcrumbs/store.rb
@@ -11,6 +11,10 @@ module Raygun
         Thread.current[:breadcrumbs] = nil
       end
 
+      def self.replace(array)
+        Thread.current[:breadcrumbs] = array
+      end
+
       def self.stored
         Thread.current[:breadcrumbs]
       end

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "3.1.1"
+  VERSION = "3.1.2"
 end

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
 
   spec.add_development_dependency 'rails', "= 5.2"
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "launchy"


### PR DESCRIPTION
Opinion: "raygun4ruby encountered an exception processing your exception" is reported when the original exception fails to be reported. The goal of the failsafe report is to be as minimal as possible to increase the likelihood of successfully making its way to Raygun. With this in mind, it is my belief that the breadcrumbs store (and possibly other tertiary reporting features that I'm not aware of) should be cleared before reporting the failsafe message.

In this PR we simply discard extra state such as breadcrumbs when reporting the "raygun4ruby encountered an exception processing your exception", to reduce the chance of failsafe report failure.