### PR TITLE
Improve failsafe exception retrying & large breadcrumb support

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -6,11 +6,6 @@ require "socket"
 require "rack"
 require "ostruct"
 
-begin
-  require "pry"
-rescue LoadError
-end
-
 require "raygun/version"
 require "raygun/configuration"
 require "raygun/client"

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -152,6 +152,8 @@ module Raygun
         env[:custom_data] ||= {}
         env[:custom_data].merge!(original_stacktrace: exception_instance.backtrace)
 
+        ::Raygun::Breadcrumbs::Store.clear
+
         track_exception(new_exception, env, user, retry_count - 1)
       else
         raise e

--- a/lib/raygun/breadcrumbs/breadcrumb.rb
+++ b/lib/raygun/breadcrumbs/breadcrumb.rb
@@ -25,6 +25,10 @@ module Raygun
           v != nil
         end]
       end
+
+      def size
+        return message.length + 100
+      end
     end
   end
 end

--- a/lib/raygun/breadcrumbs/store.rb
+++ b/lib/raygun/breadcrumbs/store.rb
@@ -47,6 +47,16 @@ module Raygun
         stored != nil && stored.length > 0
       end
 
+      def self.take_until_size(size)
+        breadcrumb_size = 0
+
+        stored.reverse.take_while do |crumb|
+          breadcrumb_size += crumb.size
+
+          breadcrumb_size < size
+        end.reverse
+      end
+
       private
 
       def self.should_record?(crumb)

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -215,13 +215,7 @@ module Raygun
             }
         }
         store = ::Raygun::Breadcrumbs::Store
-        breadcrumb_size = 0
-        breadcrumbs_to_keep = store.stored.reverse.take_while do |crumb|
-          breadcrumb_size += crumb.size
-
-          breadcrumb_size < MAX_BREADCRUMBS_SIZE
-        end.reverse
-        error_details[:breadcrumbs] = breadcrumbs_to_keep.map(&:build_payload) if store.any?
+        error_details[:breadcrumbs] = store.take_until_size(MAX_BREADCRUMBS_SIZE).map(&:build_payload) if store.any?
 
         Raygun.log('set details and breadcrumbs')
 

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
 
   spec.add_development_dependency 'rails', "= 5.2"
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'capybara'
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "launchy"

--- a/spec/raygun/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/raygun/breadcrumbs/breadcrumb_spec.rb
@@ -129,6 +129,43 @@ module Raygun
           expect(payload[:CustomData]).to eq(foo: 'bar')
         end
       end
+
+      describe "#size" do
+        before do
+          Timecop.freeze
+          Store.initialize
+        end
+        after do
+          Timecop.return
+          Store.clear
+        end
+
+        let(:message) { "This is a breadcrumb message" }
+
+        let(:breadcrumb) do
+          Store.record(
+            message: message,
+            category: "test",
+            level: :info,
+            class_name: "HomeController",
+            method_name: "index",
+            line_number: 17,
+            metadata: {
+              foo: 'bar'
+            }
+          )
+
+          Store.stored[0]
+        end
+
+        let(:size) { breadcrumb.size }
+
+        it "returns the estimated size of the breadcrumb" do
+          # Can't check all the fields but message so assume a standard 100 length for all of them
+          # The message should be the bulk of large breadcrumbs anyway
+          expect(size).to eq(message.length + 100)
+        end
+      end
     end
   end
 end

--- a/spec/raygun/breadcrumbs/store_spec.rb
+++ b/spec/raygun/breadcrumbs/store_spec.rb
@@ -67,6 +67,30 @@ module Raygun
         end
       end
 
+      describe "#take_until_size" do
+        before do
+          subject.initialize
+        end
+
+        it "takes the most recent breadcrumbs until the size limit is reached" do
+          subject.record(message: '1' * 100)
+          subject.record(message: '2' * 100)
+          subject.record(message: '3' * 100)
+
+          crumbs = subject.take_until_size(500)
+
+          expect(crumbs.length).to eq(2)
+          expect(crumbs[0].message).to eq('2' * 100)
+          expect(crumbs[1].message).to eq('3' * 100)
+        end
+
+        it "does not crash with no recorded breadcrumbs" do
+          crumbs = subject.take_until_size(500)
+
+          expect(crumbs).to eq([])
+        end
+      end
+
       context "adding a breadcrumb" do
         class Foo
           include ::Raygun::Breadcrumbs


### PR DESCRIPTION
When sending an exception causes an exception, clear the breadcrumbs store before trying to send the failure exception. This is partially because sending a giant exception payload causes an exception which could be caused by breadcrumbs (this is mitigated with the second change however) and because something in the breadcrumbs could be causing the problem.

The primary mitigation to the error that occurs during sending a very large payload is to only send the most recent breadcrumbs up to a size limit of 100KB which should address this problem without having to lose all the breadcrumbs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mindscapehq/raygun4ruby/147)
<!-- Reviewable:end -->
