### PR TITLE
Use Kernel.caller if exception has nil backtrace

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -58,6 +58,8 @@ module Raygun
 
     def track_exception(exception_instance, env = {}, user = nil, retry_count = 1)
       log('tracking exception')
+      
+      exception_instance.set_backtrace(caller) if exception_instance.is_a?(Exception) && exception_instance.backtrace.nil?
 
       if configuration.send_in_background
         track_exception_async(exception_instance, env, user, retry_count)


### PR DESCRIPTION
Hi, I wrote something like this into our raygun wrapper module in our application code and thought might as well see if you think more of your users would enjoy this feature.

### Contrived illustration of the problem

Instantiated and Tracked vs Instantiated, Raised, Rescued, and Tracked

#### Instantiated and Tracked

This error has `backtrace` of `nil`:

```ruby
error = StandardError.new("I'm an error")
track_exception(error) unless some_condition?
```

vs

#### Instantiated, Raised, Rescued, and Tracked

This error has a complete `backtrace`:

```ruby
begin
  raise StandardError.new("I'm an error") unless some_condition?
rescue StandardError => error
  track_exception(error)
end
```

### Easiest solution

- This PR makes it so if the `error` does not have a `backtrace` already, `track_exception` will call `set_backtrace` and pass in the current callstack using [Ruby `Kernel`'s `caller` method thanks to this StackOverflow post](https://stackoverflow.com/a/21620257/2696867)

#### Avoid this message on your errors in raygun portal:

> No stacktrace data is available for this error.
> Find out why script errors can contain missing details.
> If the error was manually sent then check that the data contains a properly formed error payload. Read our API documentation for more information.

### Caveats

 - Now `track_exception` is mutating its argument. This is fine for me in our application code, but probably not ideal for library code. Maybe you'd want to `.dup` the error and mutate that one instead of mutating the argument error object directly?