### PR TITLE
fix typo in method call: respond_to? vs responds_to?

### DIFF
--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -119,7 +119,7 @@ module Raygun
     def track_exception_async(*args)
       future = Concurrent::Future.execute { track_exception_sync(*args) }
       future.add_observer(lambda do |_, value, reason|
-        if value == nil || !value.responds_to?(:response) || value.response.code != "202"
+        if value == nil || !value.respond_to?(:response) || value.response.code != "202"
           log("unexpected response from Raygun, could indicate error: #{value.inspect}")
         end
       end, :call)


### PR DESCRIPTION
I've seen this crashing in our Sinatra app and I realised that the method should be called `#respond_to?`.