### PR TITLE
Update instances of raygun.io to raygun.com, update old links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this line to your application's Gemfile:
 
 And then execute:
 
-    $ bundle
+    $ bundle install
 
 Or install it yourself as:
 
@@ -25,7 +25,7 @@ Run:
 
     rails g raygun:install YOUR_API_KEY_HERE
 
-You can find your API key on your [Raygun Dashboard](https://app.raygun.com/dashboard/)
+You can find your API key in the [Raygun app](https://app.raygun.com/)
 
 You can then test your Raygun integration by running:
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ rescue => e
 end
 ```
 
-You can also pass a Hash as the second parameter to `track_exception`. It should look like a [Rack Env Hash](https://www.rubydoc.info/github/rack/rack/master/file/SPEC)
+You can also pass a Hash as the second parameter to `track_exception`. It should look like a [Rack Env Hash](https://github.com/rack/rack/blob/master/SPEC.rdoc#label-The+Environment)
 
 ### Customizing The Parameter Filtering
 
@@ -244,7 +244,7 @@ AbstractController::ActionNotFound
 Mongoid::Errors::DocumentNotFound
 ```
 
- [You can see this here](https://github.com/MindscapeHQ/raygun4ruby/blob/master/lib/raygun/configuration.rb#L51) and unignore them if needed by doing the following:
+ [You can see this here](https://github.com/MindscapeHQ/raygun4ruby/blob/master/lib/raygun/configuration.rb#L90) and unignore them if needed by doing the following:
 
 ```ruby
 Raygun.setup do |config|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Raygun 4 Ruby [![Build Status](https://travis-ci.org/MindscapeHQ/raygun4ruby.png?branch=master)](https://travis-ci.org/MindscapeHQ/raygun4ruby) [![Gem Version](https://badge.fury.io/rb/raygun4ruby.svg)](https://badge.fury.io/rb/raygun4ruby)
 
-This is the Ruby adapter for the Raygun error reporter, http://raygun.io.
+This is the Ruby adapter for the Raygun error reporter, https://raygun.com.
 
 
 ## Installation
@@ -25,7 +25,7 @@ Run:
 
     rails g raygun:install YOUR_API_KEY_HERE
 
-You can find your API key on your [Raygun Dashboard](https://app.raygun.io/dashboard/)
+You can find your API key on your [Raygun Dashboard](https://app.raygun.com/dashboard/)
 
 You can then test your Raygun integration by running:
 
@@ -41,7 +41,7 @@ By default the Rails integration is set to only report Exceptions in Production.
 
 ### Rails 2
 
-Raygun4Ruby doesn't currently support Rails 2. If you'd like Rails 2 support, [drop us a line](http://raygun.io/forums).
+Raygun4Ruby doesn't currently support Rails 2. If you'd like Rails 2 support, [drop us a line](https://raygun.com/forums).
 
 ### Sinatra
 

--- a/lib/raygun/client.rb
+++ b/lib/raygun/client.rb
@@ -1,10 +1,10 @@
 module Raygun
   # client for the Raygun REST APIv1
-  # as per http://raygun.io/raygun-providers/rest-json-api?v=1
+  # as per https://raygun.com/documentation/product-guides/crash-reporting/api/
   class Client
 
     ENV_IP_ADDRESS_KEYS = %w(action_dispatch.remote_ip raygun.remote_ip REMOTE_ADDR)
-    NO_API_KEY_MESSAGE  = "[RAYGUN] Just a note, you've got no API Key configured, which means we can't report exceptions. Specify your Raygun API key using Raygun#setup (find yours at https://app.raygun.io)"
+    NO_API_KEY_MESSAGE  = "[RAYGUN] Just a note, you've got no API Key configured, which means we can't report exceptions. Specify your Raygun API key using Raygun#setup (find yours at https://app.raygun.com)"
     MAX_BREADCRUMBS_SIZE = 100_000
 
     include HTTParty
@@ -164,7 +164,7 @@ module Raygun
         filter_params_with_blacklist(params, env["action_dispatch.parameter_filter"])
       end
 
-      # see http://raygun.io/raygun-providers/rest-json-api?v=1
+      # see https://raygun.com/documentation/product-guides/crash-reporting/api/
       def build_payload_hash(exception_instance, env = {}, user = nil)
         Raygun.log('building payload hash')
         custom_data = filter_custom_data(env) || {}

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -22,13 +22,13 @@ module Raygun
       end
     end
 
-    # Your Raygun API Key - this can be found on your dashboard at Raygun.io
+    # Your Raygun API Key - this can be found on your dashboard at https://app.raygun.com
     config_option :api_key
 
     # Your JS Raygun API Key - Should be different to your api_key, it's best practice to separate your errors between front end and back end.
     config_option :js_api_key
 
-    # Your JS Raygun API Version, defaults to latest as found on https://raygun.com/raygun-providers/javascript
+    # Your JS Raygun API Version, defaults to latest as found on https://raygun.com/documentation/language-guides/javascript/crash-reporting/installation/
     config_option :js_api_version
 
     # Array of exception classes to ignore
@@ -135,7 +135,7 @@ module Raygun
         whitelist_payload_shape:       DEFAULT_WHITELIST_PAYLOAD_SHAPE,
         proxy_settings:                {},
         debug:                         false,
-        api_url:                       'https://api.raygun.io/',
+        api_url:                       'https://api.raygun.com/',
         breadcrumb_level:              :info,
         record_raw_data:               false,
         send_in_background:            false,

--- a/lib/raygun/testable.rb
+++ b/lib/raygun/testable.rb
@@ -11,7 +11,7 @@ module Raygun
       response = Raygun.track_exception(e)
 
       if response.success?
-        puts "Success! Now go check your Raygun.io Dashboard"
+        puts "Success! Now go check your Raygun Dashboard"
       else
         puts "Oh-oh, something went wrong - double check your API key"
         puts "API Key - " << Raygun.configuration.api_key << ")"

--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |spec|
   spec.name          = "raygun4ruby"
   spec.version       = Raygun::VERSION
   spec.authors       = ["Mindscape", "Nik Wakelin"]
-  spec.email         = ["hello@raygun.io"]
-  spec.description   = %q{Ruby Adapter for Raygun.io}
-  spec.summary       = %q{This gem provides support for Ruby and Ruby on Rails for the Raygun.io error reporter}
-  spec.homepage      = "http://raygun.io"
+  spec.email         = ["hello@raygun.com"]
+  spec.description   = %q{Ruby Adapter for Raygun}
+  spec.summary       = %q{This gem provides support for Ruby and Ruby on Rails for the Raygun error reporter}
+  spec.homepage      = "https://raygun.com"
   spec.license       = "MIT"
   spec.required_ruby_version = '>= 2.0'
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -55,7 +55,7 @@ class Raygun::UnitTest < MiniTest::Unit::TestCase
   end
 
   def fake_successful_entry
-    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
+    stub_request(:post, 'https://api.raygun.com/entries').to_return(status: 202)
   end
 
   def reset_configuration

--- a/test/unit/configuration_test.rb
+++ b/test/unit/configuration_test.rb
@@ -159,7 +159,7 @@ class ConfigurationTest < Raygun::UnitTest
   end
 
   def test_api_url_default
-    assert_equal "https://api.raygun.io/", Raygun.configuration.api_url
+    assert_equal "https://api.raygun.com/", Raygun.configuration.api_url
   end
 
   def test_setting_breadcrumb_level

--- a/test/unit/resque_failure_test.rb
+++ b/test/unit/resque_failure_test.rb
@@ -8,7 +8,7 @@ class ResqueFailureTest < Raygun::UnitTest
   def setup
     super
 
-    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
+    stub_request(:post, 'https://api.raygun.com/entries').to_return(status: 202)
     fake_successful_entry
   end
 

--- a/test/unit/sidekiq_failure_test.rb
+++ b/test/unit/sidekiq_failure_test.rb
@@ -14,7 +14,7 @@ class SidekiqFailureTest < Raygun::UnitTest
   def setup
     super
 
-    stub_request(:post, 'https://api.raygun.io/entries').to_return(status: 202)
+    stub_request(:post, 'https://api.raygun.com/entries').to_return(status: 202)
     fake_successful_entry
   end
 


### PR DESCRIPTION
## Updates

- Change instances of raygun.io to raygun.com
- Update old links to point at the docs
- Update API base URL from `api.raygun.io` to `api.raygun.com`