### PR TITLE
[Customers Product]: Change references from 'Users' to 'Customers' within documentation 👥

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,12 @@ Bugfixes
 ## 2.4.0 (31/07/2017)
 
 Features
-  - Add functionality to track affected user in Sidekiq jobs, refer to the README for more information, under the "Affected User Tracking in Sidekiq" heading ([#121](https://github.com/MindscapeHQ/raygun4ruby/pull/121))
+  - Add functionality to track affected user/customer in Sidekiq jobs, refer to the README for more information, under the "Affected User Tracking/Customers in Sidekiq" heading ([#121](https://github.com/MindscapeHQ/raygun4ruby/pull/121))
 
 ## 2.3.0 (09/05/2017)"
 
 Bugfixes
-  - Fix issue preventing affected users for a crash report from showing up in the affected users page ([#119](https://github.com/MindscapeHQ/raygun4ruby/pull/119))
+  - Fix issue preventing affected users/customers for a crash report from showing up in the affected users/customers page ([#119](https://github.com/MindscapeHQ/raygun4ruby/pull/119))
 
 ## 2.2.0 (05/05/2017)
 
@@ -103,7 +103,7 @@ Features:
 
 Features:
   - Improve affected user handling to let you specify all Raygun parameters, identifier, email, first name, full name and uuid. See [README.md](https://github.com/MindscapeHQ/raygun4ruby#affected-user-tracking) for details ([#34](https://github.com/MindscapeHQ/raygun4ruby/pull/34))
-  - Pass a user object as the third parameter to `Raygun.track_exception` to have affected user tracking for manually tracked exceptions, see the above link for more information on configuring this ([#106](https://github.com/MindscapeHQ/raygun4ruby/pull/106))
+  - Pass a user object as the third parameter to `Raygun.track_exception` to have affected user tracking/customers for manually tracked exceptions, see the above link for more information on configuring this ([#106](https://github.com/MindscapeHQ/raygun4ruby/pull/106))
   - If the exception instance responds to `:raygun_custom_data` that method will be called and the return value merged into the `custom_data` hash sent to Raygun. For convenience a `Raygun::Error` class is provided that takes this custom data as a second argument ([#101](https://github.com/MindscapeHQ/raygun4ruby/pull/101))
   - Allowed `Configuration.custom_data` to be set to a proc to allow a global custom data hook for all exceptions. It is passed as arguments the exception and the environment hash ([#108](https://github.com/MindscapeHQ/raygun4ruby/pull/108))
   - Added `Configuration.debug` to enable logging the reason why an exception was not reported ([#109](https://github.com/MindscapeHQ/raygun4ruby/pull/109))

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ rescue => e
   Raygun.track_exception(e)
 end
 
-# You may also pass a user object as the third argument to allow affected user tracking, like so
+# You may also pass a user object as the third argument to allow affected customers, like so
 begin
   # your lovely code here
 rescue => e
@@ -264,13 +264,13 @@ Raygun.setup do |config|
 end
 ```
 
-### Affected User Tracking
+### Affected Customers
 
-Raygun can now track how many users have been affected by an error.
+Raygun can now track how many customers have been affected by an error.
 
-By default, Raygun looks for a method called `current_user` on your controller, and it will populate the user's information based on a default method name mapping.
+By default, Raygun looks for a method called `current_user` on your controller, and it will populate the customer's information based on a default method name mapping.
 
-(e.g Raygun will call `email` to populate the user's email, and `first_name` for the user's first name)
+(e.g Raygun will call `email` to populate the customer's email, and `first_name` for the customer's first name)
 
 You can inspect and customize this mapping using `config.affected_user_mapping`, like so:
 
@@ -291,7 +291,7 @@ To see the defaults check out [affected_user.rb](https://github.com/MindscapeHQ/
 
 If you're using Rails, most authentication systems will have this method set and you should be good to go.
 
-The count of unique affected users will appear on the error group in the Raygun dashboard. If your user has an `Email` attribute, and that email has a Gravatar associated with that address, you will also see your user's avatar.
+The count of unique affected customers will appear on the error group in the Raygun dashboard. If your customer has an `Email` attribute, and that email has a Gravatar associated with that address, you will also see your customer's avatar.
 
 If you wish to keep it anonymous, you could set this identifier to something like `SecureRandom.uuid` and store that in a cookie, like so:
 
@@ -371,11 +371,11 @@ Raygun4Ruby can track errors from Sidekiq (2.x or 3+). All you need to do is add
 
 Either in your Raygun initializer or wherever else takes your fancy :)
 
-#### Affected User Tracking in Sidekiq
+#### Affected Customers in Sidekiq
 
-To track affected users, define a class method on your worker class that returns a user object.
+To track affected customers, define a class method on your worker class that returns a user object.
 Make sure the name of this method is the same as whatever you have defined as the `affected_user_method` in your Raygun configuration and that it returns an object that fits the mappings defined in `affected_user_mapping`
-If you have not changed these, refer to [Affected user tracking](#affected-user-tracking) for the defaults
+If you have not changed these, refer to [Affected customers](#affected-customers) for the defaults
 
 ```ruby
 class FailingWorker


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' 👤

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application. Changes to 'users' within the code needs to be discussed and planned for.**

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**Updates**
👉 Update `README` documentation
👉 Update `CHANGELOG` documentation

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'User Tracking'

### Checklist ✔️ 
- [ ] Builds pass
- [ ] Reviewed by another developer
- [ ] Code is written to standards