### PR TITLE
Set sidekiq tag on sidekiq errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.4 (11/02/2021):
+  - Set sidekiq tag on sidekiq errors ([#161](https://github.com/MindscapeHQ/raygun4ruby/pull/161))
+
 ## 3.2.2 (10/06/2020):
   - Introduce support for Raygun APM exceptions correlation ([#154](https://github.com/MindscapeHQ/raygun4ruby/pull/154))
 

--- a/lib/raygun/sidekiq.rb
+++ b/lib/raygun/sidekiq.rb
@@ -23,7 +23,8 @@ module Raygun
       data =  {
         custom_data: {
           sidekiq_context: context_hash
-        }
+        },
+        tags: ['sidekiq']
       }
       if correlation_id = exception.instance_variable_get(:@__raygun_correlation_id)
         data.merge!(correlation_id: correlation_id)

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "3.2.3"
+  VERSION = "3.2.4"
 end


### PR DESCRIPTION
This change will cause errors originating from sidekiq code to be tagged with `sidekiq` in Crash Reporting in the Raygun app.

![image](https://user-images.githubusercontent.com/57920837/107598883-da111400-6c83-11eb-824b-2aabe4b40e39.png)


Closes #159