### PR TITLE
Rename Testable class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.6 (17/03/2021):
+  - Bug fix: Rename Testable class to DemoException to ensure it is added to the bundle ([#166](https://github.com/MindscapeHQ/raygun4ruby/pull/166))
+
 ## 3.2.5 (15/03/2021):
   - Bug fix: Ensure tags passed into track_exception are not persisted ([#164](https://github.com/MindscapeHQ/raygun4ruby/pull/164))
 

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -13,7 +13,7 @@ require "raygun/javascript_tracker"
 require "raygun/middleware/rack_exception_interceptor"
 require "raygun/middleware/breadcrumbs_store_initializer"
 require "raygun/middleware/javascript_exception_tracking"
-require "raygun/raygun_testable"
+require "raygun/demo_exception"
 require "raygun/error"
 require "raygun/affected_user"
 require "raygun/services/apply_whitelist_filter_to_payload"
@@ -29,7 +29,7 @@ module Raygun
   CLIENT_NAME = "Raygun4Ruby Gem"
 
   class << self
-    include RaygunTestable
+    include DemoException
 
     # Configuration Object (instance of Raygun::Configuration)
     attr_writer :configuration

--- a/lib/raygun.rb
+++ b/lib/raygun.rb
@@ -13,7 +13,7 @@ require "raygun/javascript_tracker"
 require "raygun/middleware/rack_exception_interceptor"
 require "raygun/middleware/breadcrumbs_store_initializer"
 require "raygun/middleware/javascript_exception_tracking"
-require "raygun/testable"
+require "raygun/raygun_testable"
 require "raygun/error"
 require "raygun/affected_user"
 require "raygun/services/apply_whitelist_filter_to_payload"
@@ -29,7 +29,7 @@ module Raygun
   CLIENT_NAME = "Raygun4Ruby Gem"
 
   class << self
-    include Testable
+    include RaygunTestable
 
     # Configuration Object (instance of Raygun::Configuration)
     attr_writer :configuration

--- a/lib/raygun/demo_exception.rb
+++ b/lib/raygun/demo_exception.rb
@@ -2,7 +2,7 @@ module Raygun
 
   class ItWorksException < StandardError; end
 
-  module RaygunTestable
+  module DemoException
 
     def track_test_exception
       Raygun.configuration.silence_reporting = false

--- a/lib/raygun/raygun_testable.rb
+++ b/lib/raygun/raygun_testable.rb
@@ -2,7 +2,7 @@ module Raygun
 
   class ItWorksException < StandardError; end
 
-  module Testable
+  module RaygunTestable
 
     def track_test_exception
       Raygun.configuration.silence_reporting = false

--- a/lib/raygun/version.rb
+++ b/lib/raygun/version.rb
@@ -1,3 +1,3 @@
 module Raygun
-  VERSION = "3.2.5"
+  VERSION = "3.2.6"
 end


### PR DESCRIPTION
## Overview

In Ruby 2.7.2, the built gem does not include the `lib/raygun/testable.rb` file due to the regex in the gemspec [here](https://github.com/MindscapeHQ/raygun4ruby/blob/master/raygun4ruby.gemspec#L17). This has been renamed so that it no longer contains "test" in the file name.