### PR TITLE
Don't load Raygun until after `ActionDispatch`

### DIFF
--- a/lib/raygun/railtie.rb
+++ b/lib/raygun/railtie.rb
@@ -2,29 +2,30 @@ require "raygun/middleware/rails_insert_affected_user"
 
 class Raygun::Railtie < Rails::Railtie
   initializer "raygun.configure_rails_initialization" do |app|
+    ActiveSupport.on_load(:action_dispatch_request, run_once: true) do
+      # Thanks Airbrake: See https://github.com/rails/rails/pull/8624
+      middleware = if defined?(ActionDispatch::DebugExceptions)
+                    if Rails::VERSION::STRING >= "5"
+                      ActionDispatch::DebugExceptions
+                    else
+                      # Rails >= 3.2.0
+                      "ActionDispatch::DebugExceptions"
+                    end
+                  else
+                    # Rails < 3.2.0
+                    "ActionDispatch::ShowExceptions"
+                  end
 
-    # Thanks Airbrake: See https://github.com/rails/rails/pull/8624
-    middleware = if defined?(ActionDispatch::DebugExceptions)
-                   if Rails::VERSION::STRING >= "5"
-                     ActionDispatch::DebugExceptions
-                   else
-                     # Rails >= 3.2.0
-                     "ActionDispatch::DebugExceptions"
-                   end
-                 else
-                   # Rails < 3.2.0
-                   "ActionDispatch::ShowExceptions"
-                 end
-
-    raygun_middleware = [
-      Raygun::Middleware::RailsInsertAffectedUser,
-      Raygun::Middleware::RackExceptionInterceptor,
-      Raygun::Middleware::BreadcrumbsStoreInitializer,
-      Raygun::Middleware::JavascriptExceptionTracking
-    ]
-    raygun_middleware = raygun_middleware.map(&:to_s) unless Rails::VERSION::STRING >= "5"
-    raygun_middleware.each do |m|
-      app.config.middleware.insert_after(middleware, m)
+      raygun_middleware = [
+        Raygun::Middleware::RailsInsertAffectedUser,
+        Raygun::Middleware::RackExceptionInterceptor,
+        Raygun::Middleware::BreadcrumbsStoreInitializer,
+        Raygun::Middleware::JavascriptExceptionTracking
+      ]
+      raygun_middleware = raygun_middleware.map(&:to_s) unless Rails::VERSION::STRING >= "5"
+      raygun_middleware.each do |m|
+        app.config.middleware.insert_after(middleware, m)
+      end
     end
   end
 


### PR DESCRIPTION
Raygun relies on the `ActionDispatch::DebugExceptions` middleware in Rails. This change causes Raygun to only insert its middleware after ActionDispatch is loaded.

This is necessary because recently the load order of Rails appears to
have changed, which means Raygun users on Rails Edge (7.0.0.alpha) may
have been getting a message similar to:

```
NameError: uninitialized constant ActionDispatch::DebugExceptions
```

Originating in `raygun4ruby-3.2.6/lib/raygun/railtie.rb:9:in `block in <class:Railtie>'`

This change shouldn't affect Rails 5/6, although it may affect versions 2+ years old as the hook looks like was installed 2 years ago.