### PR TITLE
Adds internal Sidekiq class to default ignore list

### DIFF
--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -97,7 +97,8 @@ module Raygun
                       'CGI::Session::CookieStore::TamperedWithCookie',
                       'ActionController::UnknownAction',
                       'AbstractController::ActionNotFound',
-                      'Mongoid::Errors::DocumentNotFound']
+                      'Mongoid::Errors::DocumentNotFound',
+                      'Sidekiq::JobRetry::Skip']
 
     DEFAULT_FILTER_PARAMETERS = [ :password, :card_number, :cvv ]
 


### PR DESCRIPTION
`Sidekiq::JobRetry::Skip` is used for retry control and isn't really a resolvable error to track

As per [recommendation from the Sidekiq maintainer](https://github.com/rails/rails/pull/43625#issuecomment-1071632022)