### PR TITLE
Fixes backward incompatible Sidekiq change

### DIFF
--- a/lib/raygun/sidekiq.rb
+++ b/lib/raygun/sidekiq.rb
@@ -6,7 +6,7 @@
 module Raygun
 
   class SidekiqReporter
-    def self.call(exception, context_hash, config)
+    def self.call(exception, context_hash = {}, config = nil)
       user = affected_user(context_hash)
       data =  {
         custom_data: {

--- a/test/unit/sidekiq_failure_test.rb
+++ b/test/unit/sidekiq_failure_test.rb
@@ -32,6 +32,17 @@ class SidekiqFailureTest < Raygun::UnitTest
     assert response && response.success?, "Expected success, got #{response.class}: #{response.inspect}"
   end
 
+  # See https://github.com/MindscapeHQ/raygun4ruby/issues/183
+  # (This is how Sidekiq pre 7.1.5 calls error handlers: https://github.com/sidekiq/sidekiq/blob/1ba89bbb22d2fd574b11702d8b6ed63ae59e2256/lib/sidekiq/config.rb#L269)
+  def test_failure_backend_appears_to_work_without_config_argument
+    response = Raygun::SidekiqReporter.call(
+      StandardError.new("Oh no! Your Sidekiq has failed!"),
+      { sidekick_name: "robin" }
+    )
+
+    assert response && response.success?, "Expected success, got #{response.class}: #{response.inspect}"
+  end
+
   def test_we_are_in_sidekiqs_list_of_error_handlers
     # Sidekiq 7.x stores error handlers inside a configuration object, while 6.x and below stores them directly against the Sidekiq module
     error_handlers = Sidekiq.respond_to?(:error_handlers) ? Sidekiq.error_handlers : Sidekiq.default_configuration.error_handlers


### PR DESCRIPTION
We are expecting a `config` argument to the Sidekiq exception handler, but pre- version 7.1.5 that is not passed.

So we'll make the argument optional as it is currently unnused anyway

Fixes #183