### PR TITLE
Unwraps `Sidekiq::JobRetry::Handled` errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ class FailingWorker
   end
 ```
 
+##### Sidekiq Retries
+
+By default, Raygun4Ruby will unwrap `Sidekiq::JobRetry::Handled` exceptions and report the original error via `Exception#cause`. If you would prefer not to hear about retries, you can set `config.track_retried_sidekiq_jobs` to `false` in your Raygun configuration.
+
 ### Other Configuration options
 
 For a complete list of configuration options see the [configuration.rb](https://github.com/MindscapeHQ/raygun4ruby/blob/master/lib/raygun/configuration.rb) file

--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -89,6 +89,9 @@ module Raygun
     # Should we register an error handler with [Rails' built in API](https://edgeguides.rubyonrails.org/error_reporting.html)
     config_option :register_rails_error_handler
 
+    # Should we track jobs that are retried in Sidekiq (ones that raise Sidekiq::JobRetry::Handled). Set to "false" to ignore.
+    config_option :track_retried_sidekiq_jobs
+
     # Exception classes to ignore by default
     IGNORE_DEFAULT = ['ActiveRecord::RecordNotFound',
                       'ActionController::RoutingError',
@@ -143,7 +146,8 @@ module Raygun
         breadcrumb_level:              :info,
         record_raw_data:               false,
         send_in_background:            false,
-        error_report_send_timeout:     10
+        error_report_send_timeout:     10,
+        track_retried_sidekiq_jobs:    true
       )
     end
 

--- a/lib/raygun/error_subscriber.rb
+++ b/lib/raygun/error_subscriber.rb
@@ -16,6 +16,10 @@ class Raygun::ErrorSubscriber
       tags: ["rails_error_reporter", *tags].compact
     }
 
-    Raygun.track_exception(error, data)
+    if source == "job.sidekiq" && defined?(Sidekiq)
+      Raygun::SidekiqReporter.call(error, data)
+    else
+      Raygun.track_exception(error, data)
+    end
   end
 end

--- a/lib/raygun/sidekiq.rb
+++ b/lib/raygun/sidekiq.rb
@@ -14,6 +14,16 @@ module Raygun
         },
         tags: ['sidekiq']
       }
+
+      if exception.is_a?(Sidekiq::JobRetry::Handled) && exception.cause
+        if Raygun.configuration.track_retried_sidekiq_jobs
+          data.merge!(sidekiq_retried: true)
+          exception = exception.cause
+        else
+          return false
+        end
+      end
+
       if exception.instance_variable_defined?(:@__raygun_correlation_id) && correlation_id = exception.instance_variable_get(:@__raygun_correlation_id)
         data.merge!(correlation_id: correlation_id)
       end

--- a/test/unit/sidekiq_failure_test.rb
+++ b/test/unit/sidekiq_failure_test.rb
@@ -1,6 +1,7 @@
 require_relative "../test_helper.rb"
 
 require "sidekiq"
+
 # Convince Sidekiq it's on a server :)
 module Sidekiq
   class << self
@@ -15,6 +16,8 @@ require "raygun/sidekiq"
 class SidekiqFailureTest < Raygun::UnitTest
 
   def setup
+    require "sidekiq/job_retry"
+
     super
     Raygun.configuration.send_in_background = false
 
@@ -30,6 +33,50 @@ class SidekiqFailureTest < Raygun::UnitTest
     )
 
     assert response && response.success?, "Expected success, got #{response.class}: #{response.inspect}"
+  end
+
+  def test_failure_backend_unwraps_retries
+    WebMock.reset!
+
+    unwrapped_stub = stub_request(:post, 'https://api.raygun.com/entries').
+      with(body: /StandardError/).
+      to_return(status: 202)
+
+    begin
+      raise StandardError.new("Some job in Sidekiq failed, oh dear!")
+    rescue
+      raise Sidekiq::JobRetry::Handled
+    end
+
+    rescue Sidekiq::JobRetry::Handled => e
+
+      response = Raygun::SidekiqReporter.call(
+        e,
+        { sidekick_name: "robin" }, 
+        {} # config
+      )
+
+      assert_requested unwrapped_stub
+      assert response && response.success?, "Expected success, got #{response.class}: #{response.inspect}"
+  end
+
+  def test_failured_backend_ignores_retries_if_configured
+    Raygun.configuration.track_retried_sidekiq_jobs = false
+    
+    begin
+      raise StandardError.new("Some job in Sidekiq failed, oh dear!")
+    rescue
+      raise Sidekiq::JobRetry::Handled
+    end
+
+    rescue Sidekiq::JobRetry::Handled => e
+
+      refute Raygun::SidekiqReporter.call(e,
+        { sidekick_name: "robin" }, 
+        {} # config
+      )
+  ensure
+    Raygun.configuration.track_retried_sidekiq_jobs = true
   end
 
   # See https://github.com/MindscapeHQ/raygun4ruby/issues/183


### PR DESCRIPTION
This means the inner exception is reported to Raygun, with a tag `sidekiq_retry` of "true".

Also adds a config setting to disable this behaviour and reporting of retried Sidekiq jobs (`config.track_retried_sidekiq_jobs` defaults to true)