### PR TITLE
Adds support for a retry count and raising

### DIFF
--- a/lib/raygun/configuration.rb
+++ b/lib/raygun/configuration.rb
@@ -86,6 +86,12 @@ module Raygun
     # How long to wait for the POST request to the API server before timing out
     config_option :error_report_send_timeout
 
+    # How many times to try sending to Raygun before giving up
+    config_option :error_report_max_attempts
+
+    # Whether or not we should raise an exception if the error reporting fails
+    config_option :raise_on_failed_error_report
+
     # Should we register an error handler with [Rails' built in API](https://edgeguides.rubyonrails.org/error_reporting.html)
     config_option :register_rails_error_handler
 
@@ -147,6 +153,8 @@ module Raygun
         record_raw_data:               false,
         send_in_background:            false,
         error_report_send_timeout:     10,
+        error_report_max_attempts:     1,
+        raise_on_failed_error_report:  false,
         track_retried_sidekiq_jobs:    true
       )
     end

--- a/test/unit/sidekiq_failure_test.rb
+++ b/test/unit/sidekiq_failure_test.rb
@@ -48,16 +48,16 @@ class SidekiqFailureTest < Raygun::UnitTest
       raise Sidekiq::JobRetry::Handled
     end
 
-    rescue Sidekiq::JobRetry::Handled => e
+  rescue Sidekiq::JobRetry::Handled => e
 
-      response = Raygun::SidekiqReporter.call(
-        e,
-        { sidekick_name: "robin" }, 
-        {} # config
-      )
+    response = Raygun::SidekiqReporter.call(
+      e,
+      { sidekick_name: "robin" }, 
+      {} # config
+    )
 
-      assert_requested unwrapped_stub
-      assert response && response.success?, "Expected success, got #{response.class}: #{response.inspect}"
+    assert_requested unwrapped_stub
+    assert response && response.success?, "Expected success, got #{response.class}: #{response.inspect}"
   end
 
   def test_failured_backend_ignores_retries_if_configured
@@ -69,12 +69,12 @@ class SidekiqFailureTest < Raygun::UnitTest
       raise Sidekiq::JobRetry::Handled
     end
 
-    rescue Sidekiq::JobRetry::Handled => e
+  rescue Sidekiq::JobRetry::Handled => e
 
-      refute Raygun::SidekiqReporter.call(e,
-        { sidekick_name: "robin" }, 
-        {} # config
-      )
+    refute Raygun::SidekiqReporter.call(e,
+      { sidekick_name: "robin" }, 
+      {} # config
+    )
   ensure
     Raygun.configuration.track_retried_sidekiq_jobs = true
   end


### PR DESCRIPTION
Adds two new configuration settings:

  * Configure how many times raygun4ruby should retry sending the error to the Raygun servers using `error_report_max_attempts` (defaults to 1)
  * Configure whether or not raygun4ruby should re-raise an exception if the send fails using `raise_on_failed_error_report` (defaults to false)