### PR TITLE
Add ostruct runtime dependency to fix warning in ruby 3.3.5+

### DIFF
--- a/raygun4ruby.gemspec
+++ b/raygun4ruby.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "json"
   spec.add_runtime_dependency "rack"
   spec.add_runtime_dependency "concurrent-ruby"
+  spec.add_runtime_dependency "ostruct"
 
   spec.add_development_dependency "bundler", ">= 2.3"
   spec.add_development_dependency "rake", ">= 12.3.3"


### PR DESCRIPTION
Ruby 3.3.5 emits a warning that `ostruct` will be removed from stdlib default gems in Ruby 3.5

```
/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/raygun4ruby-x.x.x/lib/raygun.rb:7: warning:
/.rbenv/versions/3.3.5/lib/ruby/3.3.0/ostruct.rb was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```